### PR TITLE
README - Added minimum-stability property to composer.json example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation of this module uses composer. For composer documentation, please re
 
      ```json
      {
-        "minimum-stability": "dev",
+        "minimum-stability": "beta",
          "require": {
              "doctrine/doctrine-mongo-odm-module": "dev-master"
          }


### PR DESCRIPTION
This is required to be set to "dev" if Composer is to install the dependency
mongodb-odm successfully.
