### PR TITLE
concrete implementation of AbstractObjectManagerInitializer for Doctrine\ODM\Mongo\DocumentManager

### DIFF
--- a/src/DoctrineMongoODMModule/Initializer/DocumentManagerInitializer.php
+++ b/src/DoctrineMongoODMModule/Initializer/DocumentManagerInitializer.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineMongoODMModule\Initializer;
+
+use DoctrineModule\Persistence\AbstractObjectManagerInitializer;
+
+class DocumentManagerInitializer extends AbstractObjectManagerInitializer
+{
+
+	/**
+	 * Get service name to retrieve DocumentManager instance
+	 * @access protected
+	 * @return string
+	 */
+	protected function getServiceName()
+	{
+		// return Doctrine\ODM\Mongo\DocumentManager service name
+		return 'Doctrine\ODM\Mongo\DocumentManager';
+	}
+
+}


### PR DESCRIPTION
concrete implementation of AbstractObjectManagerInitializer for Doctrine\ODM\Mongo\DocumentManager

Require PR : https://github.com/doctrine/DoctrineModule/issues/168

Sample configuration : 

```
return array(
    'service_manager' => array(
        'initializers' => array(
            'documentmanager_initializer' => 'DoctrineMongoODMModule\Initializer\DocumentManagerInitializer'
        ),
    ),
);
```
