### PR TITLE
Fix to lastItemNumber in Paginator

### DIFF
--- a/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -62,7 +62,7 @@ class DoctrinePaginator implements AdapterInterface
         $cursor->recreate();
         $cursor->skip($offset);
         $cursor->limit($itemCountPerPage);
-
-        return $cursor;
+        // Return array version so that counting is correct
+        return $cursor->toArray();
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
@@ -51,44 +51,37 @@ class PaginationAdapterTest extends AbstractTest
         $this->assertEquals($this->numberOfItems, $paginationAdapter->count());
     }
 
-    public function testGetItemsReturnsACursor()
-    {
-        $paginationAdapter = $this->getPaginationAdapter();
-        $cursor = $paginationAdapter->getItems(0, 1);
-
-        $this->assertInstanceOf('Doctrine\ODM\MongoDB\Cursor', $cursor);
-    }
-
     public function testGetItemsWithFirstFive()
     {
         $paginationAdapter = $this->getPaginationAdapter();
-        $cursor = $paginationAdapter->getItems(0, 5);
-        $documents = iterator_to_array($cursor, false);
-
-        for ($i = 0; $i < 5; $i++) {
-            $this->assertEquals(sprintf('Document %02d', $i + 1), $documents[$i]->getName());
-        }
-
+        $documents = $paginationAdapter->getItems(0, 5);
+        
         $this->assertCount(5, $documents);
+        for ($i = 1; $i <= 5; $i++) {
+            $this->assertEquals(sprintf('Document %02d', $i), current($documents)->getName());
+            next($documents);
+        }
+        $this->assertEquals(false, next($documents));
     }
 
     public function testGetItemsWithLastItem()
     {
         $paginationAdapter = $this->getPaginationAdapter();
-        $cursor = $paginationAdapter->getItems($this->numberOfItems - 1, 5);
-        $documents = iterator_to_array($cursor, false);
+        $documents = $paginationAdapter->getItems($this->numberOfItems - 1, 5);
 
-        $this->assertEquals(sprintf('Document %02d', $this->numberOfItems), $documents[0]->getName());
+        $this->assertEquals(sprintf('Document %02d', $this->numberOfItems), current($documents)->getName());
         $this->assertCount(1, $documents);
+        $this->assertEquals(false, next($documents));
     }
 
     public function testGetItemsCalledTwoTimes()
     {
         $paginationAdapter = $this->getPaginationAdapter();
 
-        $document1 = current(iterator_to_array($paginationAdapter->getItems(0, 1)));
-        $document2 = current(iterator_to_array($paginationAdapter->getItems(1, 1)));
+        $document1 = current($paginationAdapter->getItems(0, 1));
+        $document2 = current($paginationAdapter->getItems(1, 1));
 
+        $this->assertNotEquals($document1->getName(), $document2->getName());
         $this->assertEquals('Document 01', $document1->getName());
         $this->assertEquals('Document 02', $document2->getName());
     }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace DoctrineMongoODMModuleTest\Doctrine;
+
+use Zend\Paginator\Paginator;
+use DoctrineMongoODMModule\Paginator\Adapter\DoctrinePaginator;
+use DoctrineMongoODMModuleTest\AbstractTest;
+use DoctrineMongoODMModuleTest\Assets\Document\Simple;
+
+/**
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Chris Levy <chrisianlevy@yahoo.co.uk>
+ */
+class PaginationTest extends AbstractTest
+{
+    /**
+     * number of items generated in tests
+     *
+     * @var int
+     */
+    protected $numberOfItems;
+
+    protected function getPaginationAdapter()
+    {
+        $documentManager = $this->getDocumentManager();
+
+        $cursor = $documentManager->getRepository(get_class(new Simple()))->findAll();
+        $cursor->sort(array('Name', 'asc'));
+
+        return new DoctrinePaginator($cursor);
+    }
+    
+    protected function getPaginator(DoctrinePaginator $adaptor)
+    {
+        return new Paginator($adaptor);
+    }
+
+    public function setup()
+    {
+        parent::setup();
+
+        $this->numberOfItems = 20;
+        $documentManager     = $this->getDocumentManager();
+
+        for ($i = 1; $i <= $this->numberOfItems; $i++) {
+            $document = new Simple();
+            $document->setName("Document $i");
+            $documentManager->persist($document);
+        }
+        $documentManager->flush();
+    }
+
+    public function testGetFoundItemCount()
+    {
+        $paginationAdapter = $this->getPaginationAdapter();
+        $paginator = $this->getPaginator($paginationAdapter);
+        $pages = $paginator->getPages();
+        
+        $this->assertEquals(10, $pages->lastItemNumber);
+    }
+}


### PR DESCRIPTION
Since the cursor returns the wrong count, we return an array. I have
updated the unit test to work with array return type. There is a new
unit test to test the counts.
