### PR TITLE
Fix for BC break caused by PR #87

### DIFF
--- a/src/DoctrineMongoODMModule/Service/ConnectionFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConnectionFactory.php
@@ -45,7 +45,7 @@ class ConnectionFactory extends AbstractFactory
 
         $connectionString = $options->getConnectionString();
 
-        if (null === $connectionString) {
+        if (empty($connectionString)) {
             $connectionString = 'mongodb://';
 
             $user     = $options->getUser();


### PR DESCRIPTION
[PR 87](https://github.com/doctrine/DoctrineMongoODMModule/pull/87) causes a BC break.

The `ConnectionFactory`'s `setConnectionString(...)` method casts `$connectionString` to `string`. This means that [this condition](https://github.com/doctrine/DoctrineMongoODMModule/blob/2a3acdf7f87d18617b9f23b16600ae255a5dee70/src/DoctrineMongoODMModule/Service/ConnectionFactory.php#L48) can never evaluate to true, which makes it impossible to use anything but `connectionString` in the configuration.
