### PR TITLE
DoctrinePaginator::getItems needs to $useKeys = false

### DIFF
--- a/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -63,6 +63,6 @@ class DoctrinePaginator implements AdapterInterface
         $cursor->skip($offset);
         $cursor->limit($itemCountPerPage);
         // Return array version so that counting is correct
-        return $cursor->toArray();
+        return $cursor->toArray(false);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
@@ -84,4 +84,14 @@ class PaginationAdapterTest extends AbstractTest
         $this->assertEquals('Document 01', $document1->getName());
         $this->assertEquals('Document 02', $document2->getName());
     }
+
+    public function testItemsAreKeyedAsSequentialIntegers()
+    {
+        $paginationAdapter = $this->getPaginationAdapter();
+        $items = $paginationAdapter->getItems(0, $paginationAdapter->count());
+
+        for ($i = 0; $i < $paginationAdapter->count(); $i++) {
+            $this->assertArrayHasKey($i, $items);
+        }
+    }
 }


### PR DESCRIPTION
Referring to [this line](https://github.com/doctrine/DoctrineMongoODMModule/blob/086e0560f8ddb81fd4e0d0de675cd3f85fe1c039/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php#L66).

While it adheres to the [Zend\Paginator\Adapter\AdapterInterface](https://github.com/zendframework/zf2/blob/release-2.3.0/library/Zend/Paginator/Adapter/AdapterInterface.php) by returning an `array`, in the case of Mongo the array will be keyed using MongoDB BSON ObjectIds. This makes [fetching a specific individual item impossible](https://github.com/zendframework/zf2/blob/release-2.3.0/library/Zend/Paginator/Paginator.php#L531) because `Zend\Paginator\Paginator` expects the result of `getItems()` to be keyed `0, 1, ..., n`.

This PR:
1. Adds the `false` parameter
2. Adds a unit test ensuring that the returned items are keyed appropriately.
3. Does not modify existing tests, so BC is preserved for anybody who was using them as a reference.
