### PR TITLE
Proxy generation option AUTOGENERATE_FILE_NOT_EXISTS allowed

### DIFF
--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -154,7 +154,7 @@ class Configuration extends AbstractOptions
      */
     public function setGenerateProxies($generateProxies)
     {
-        $this->generateProxies = (boolean) $generateProxies;
+        $this->generateProxies = ((int)$generateProxies > 2)?(boolean) $generateProxies:(int)$generateProxies;
         return $this;
     }
 


### PR DESCRIPTION
Doctrine common library has an option called AUTOGENERATE_FILE_NOT_EXISTS which is very helpful in production environments.

https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php#L60

But it had casted into a boolean value on https://github.com/doctrine/DoctrineMongoODMModule/blob/master/src/DoctrineMongoODMModule/Options/Configuration.php#L157
which prevented the option AUTOGENERATE_FILE_NOT_EXISTS (2) as below 

$this->generateProxies = (boolean) $generateProxies;

Here i am proposing an update as below 

$this->generateProxies = ((int)$generateProxies > 2)?(boolean) $generateProxies:(int)$generateProxies;
