### PR TITLE
Adding DocumentManager FQCN service alias

### DIFF
--- a/src/DoctrineMongoODMModule/Module.php
+++ b/src/DoctrineMongoODMModule/Module.php
@@ -143,6 +143,7 @@ class Module implements
             ),
             'aliases' => array(
                 'Doctrine\ODM\Mongo\DocumentManager' => 'doctrine.documentmanager.odm_default',
+                'Doctrine\ODM\MongoDB\DocumentManager' => 'doctrine.documentmanager.odm_default',
             ),
             'factories' => array(
                 'doctrine.authenticationadapter.odm_default'  => new CommonService\Authentication\AdapterFactory('odm_default'),


### PR DESCRIPTION
Just to allow `$serviceLocator->get(DocumentManager::class);`

Ping @Ocramius @superdweebie 