### PR TITLE
Add DoctrineObject factory for DocumentManager

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -70,6 +70,12 @@ return array(
             ),
         ),
     ),
+    
+    'hydrators' => array(
+        'factories' => array(
+            'DoctrineModule\Stdlib\Hydrator\DoctrineObject' => 'DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory'
+        )
+    ),
 
     // zendframework/zend-developer-tools specific settings
 

--- a/src/DoctrineMongoODMModule/Service/DoctrineObjectHydratorFactory.php
+++ b/src/DoctrineMongoODMModule/Service/DoctrineObjectHydratorFactory.php
@@ -18,18 +18,24 @@
 
 namespace DoctrineMongoODMModule\Service;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 
-class DoctrineObjectHydratorFactory implements FactoryInterface
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+
+class DoctrineObjectHydratorFactory
 {
     /**
-     * {@inheritDoc}
+     * @param HydratorPluginManager $hydratorPluginManager
+     * @return DoctrineObject
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(HydratorPluginManager $hydratorPluginManager)
     {
-        $parentLocator = $serviceLocator->getServiceLocator();
-        return new DoctrineObject($parentLocator->get('doctrine.documentmanager.odm_default'));
+        $serviceLocator = $hydratorPluginManager->getServiceLocator();
+
+        /** @var DocumentManager $documentManager */
+        $documentManager = $serviceLocator->get('doctrine.documentmanager.odm_default');
+
+        return new DoctrineObject($documentManager);
     }
 }

--- a/src/DoctrineMongoODMModule/Service/DoctrineObjectHydratorFactory.php
+++ b/src/DoctrineMongoODMModule/Service/DoctrineObjectHydratorFactory.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace DoctrineMongoODMModule\Service;
+
+use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class DoctrineObjectHydratorFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $parentLocator = $serviceLocator->getServiceLocator();
+        return new DoctrineObject($parentLocator->get('doctrine.documentmanager.odm_default'));
+    }
+}

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
@@ -2,31 +2,28 @@
 
 namespace DoctrineMongoODMModuleTest\Doctrine;
 
-use Doctrine\ODM\MongoDB\DocumentManager;
-use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory;
-use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Stdlib\Hydrator\HydratorPluginManager;
 
 class DoctrineObjectHydratorFactoryTest extends TestCase
 {
     public function testReturnsHydratorInstance()
     {
-        $serviceLocatorInterface = $this->getMock(ServiceLocatorInterface::class);
+        $serviceLocatorInterface = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
 
         $serviceLocatorInterface
             ->expects($this->once())
             ->method('get')
             ->with('doctrine.documentmanager.odm_default')
             ->willReturn(
-                $this->getMockBuilder(DocumentManager::class)
+                $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
                      ->disableOriginalConstructor()
                      ->getMock()
             );
 
         /** @var HydratorPluginManager $hydratorPluginManager */
-        $hydratorPluginManager = $this->getMock(HydratorPluginManager::class);
+        $hydratorPluginManager = $this->getMock('Zend\Stdlib\Hydrator\HydratorPluginManager');
 
         $hydratorPluginManager
             ->expects($this->once())
@@ -39,6 +36,6 @@ class DoctrineObjectHydratorFactoryTest extends TestCase
         $factory  = new DoctrineObjectHydratorFactory();
         $hydrator = $factory($hydratorPluginManager);
 
-        $this->assertInstanceOf(DoctrineObject::class, $hydrator);
+        $this->assertInstanceOf('DoctrineModule\Stdlib\Hydrator\DoctrineObject', $hydrator);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DoctrineMongoODMModuleTest\Doctrine;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
+use PHPUnit_Framework_TestCase as TestCase;
+use DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\Stdlib\Hydrator\HydratorPluginManager;
+
+class DoctrineObjectHydratorFactoryTest extends TestCase
+{
+    public function testReturnsHydratorInstance()
+    {
+        $serviceLocatorInterface = $this->getMock(ServiceLocatorInterface::class);
+
+        $serviceLocatorInterface
+            ->expects($this->once())
+            ->method('get')
+            ->with('doctrine.documentmanager.odm_default')
+            ->willReturn(
+                $this->getMockBuilder(DocumentManager::class)
+                     ->disableOriginalConstructor()
+                     ->getMock()
+            );
+
+        /** @var HydratorPluginManager $hydratorPluginManager */
+        $hydratorPluginManager = $this->getMock(HydratorPluginManager::class);
+
+        $hydratorPluginManager
+            ->expects($this->once())
+            ->method('getServiceLocator')
+            ->willReturn(
+                $serviceLocatorInterface
+            );
+
+
+        $factory  = new DoctrineObjectHydratorFactory();
+        $hydrator = $factory($hydratorPluginManager);
+
+        $this->assertInstanceOf(DoctrineObject::class, $hydrator);
+    }
+}


### PR DESCRIPTION
This allows to use the MongoDB DocumentManager as DoctrineObject hydrator default object manager, by switching module positions in zf2 app config, or removes the necessity of creating a factory for it or setting the object manager in a fieldset.