### PR TITLE
Drop PHP 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4",
         "doctrine/doctrine-module": "0.9.*",
         "doctrine/mongodb-odm": "1.0.*@dev",
         "zendframework/zend-mvc": "2.*",


### PR DESCRIPTION
DoctrineModule is php 5.4+. I guess it makes sense to drop the 5.3 support here too.