### PR TITLE
Release 0.8.2 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+## Version 0.8.2
+
+- [#108](https://github.com/doctrine/DoctrineMongoODMModule/pull/108) updated paginator documentation
+- [#108](https://github.com/doctrine/DoctrineMongoODMModule/pull/109) added user guide
+- [#114](https://github.com/doctrine/DoctrineMongoODMModule/pull/114) simplified unit testing
+- [#115](https://github.com/doctrine/DoctrineMongoODMModule/pull/115) removed files for old test setup


### PR DESCRIPTION
I'm speaking with @ocramius and this is my proposal of release.
I found into the story the last commit with DoctrineModule 0.8.* and PHP >= 5.3
In my opinion we can tag in this point the 0.8.2 the last version before changeing in 0.9.*, security issues excluded.

After this commit the master branch support DoctrineModule 0.9.* and PHP >= 5.4