### PR TITLE
Add a sensible retry config

### DIFF
--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -119,14 +119,14 @@ class Configuration extends AbstractOptions
      *
      * @var int
      */
-    protected $retryConnect = 0;
+    protected $retryConnect = 3;
 
     /**
      * Number of times to attempt a query if an exception is encountered
      *
      * @var int
      */
-    protected $retryQuery = 0;
+    protected $retryQuery = 3;
 
     /**
      * Keys must be the name of the type identifier and value is


### PR DESCRIPTION
The MongoDB service will internally expire connections without the client Mongo driver ever knowing about it. If we have a retry of 0 then when this happens (it happened with us in prod before we realised this is what was going on) we get 'random' fatals which we have to programatically handle throughout our application.

It makes more sense to have a retry default of > 0, so that when Mongo connections are expired internally, they can be re-established without needing to deal with a fatal.