### PR TITLE
Fix pagination count with eager cursors

### DIFF
--- a/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineMongoODMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -20,6 +20,7 @@
 namespace DoctrineMongoODMModule\Paginator\Adapter;
 
 use Zend\Paginator\Adapter\AdapterInterface;
+use Doctrine\MongoDB\EagerCursor;
 use Doctrine\ODM\MongoDB\Cursor;
 
 /**
@@ -30,7 +31,7 @@ use Doctrine\ODM\MongoDB\Cursor;
 class DoctrinePaginator implements AdapterInterface
 {
     /**
-     * @var Doctrine\ODM\MongoDB\Cursor
+     * @var Cursor
      */
     protected $cursor;
 
@@ -49,6 +50,11 @@ class DoctrinePaginator implements AdapterInterface
      */
     public function count()
     {
+        // Avoid using EagerCursor::count as this stores a collection without limits to memory
+        if ($this->cursor->getBaseCursor() instanceof EagerCursor) {
+            return $this->cursor->getBaseCursor()->getCursor()->count();
+        }
+
         return $this->cursor->count();
     }
 

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
@@ -52,6 +52,19 @@ class PaginationAdapterTest extends AbstractTest
         $this->assertEquals($this->numberOfItems, $paginationAdapter->count());
     }
 
+    public function testItemCountWithEagerCursor()
+    {
+        $documentManager = $this->getDocumentManager();
+
+        // Prepare an adapter with a limit already set. EagerCursors don't support $foundOnly = false
+        $cursor = $documentManager->createQueryBuilder(get_class(new Simple()))->eagerCursor(true)->getQuery()->execute();
+        $cursor->sort(array('name' => 'asc'))->limit(5);
+
+        $paginationAdapter = new DoctrinePaginator($cursor);
+
+        $this->assertEquals($this->numberOfItems, $paginationAdapter->count());
+    }
+
     public function testGetItemsWithFirstFive()
     {
         $paginationAdapter = $this->getPaginationAdapter();


### PR DESCRIPTION
This prevents issues such as doctrine/mongodb-odm#1283: using references primers implies eager cursors, which in turn don't support returning all found elements in ```count``` without being restricted by the limit set on the cursor. Furthermore, running count() on an eager cursor without a limit set would load all found items to memory to avoid future queries. This PR adds a workaround for the paginator to query the base cursor and avoid this data cache.