### PR TITLE
Update to stable package versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ services: mongodb
 
 before_script:
   - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script:
   - cd tests
   - cp test.application.config.php ../config/application.config.php
   - ../vendor/bin/doctrine-module odm:schema:create
   - ../vendor/bin/doctrine-module odm:schema:drop
-  - phpunit
+  - ../vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -39,13 +39,12 @@
     ],
     "require": {
         "php": ">=5.4",
-        "doctrine/doctrine-module": "~0.8",
-        "doctrine/mongodb-odm": "1.0.*@dev",
+        "doctrine/doctrine-module": "~1.0",
+        "doctrine/mongodb-odm": "~1.0",
         "zendframework/zend-mvc": "2.*",
         "zendframework/zend-servicemanager": "2.*",
         "zendframework/zend-stdlib": "2.*"
     },
-    "minimum-stability": "dev",
     "require-dev": {
         "zendframework/zendframework": "2.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,16 @@
         "zendframework/zend-stdlib": "2.*"
     },
     "require-dev": {
-        "zendframework/zendframework": "2.*"
+        "zendframework/zendframework": "2.*",
+        "phpunit/phpunit": "~4.8 || ~5.0"
     },
     "autoload": {
         "psr-0": {
-            "DoctrineMongoODMModule\\": "src/",
+            "DoctrineMongoODMModule\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-0": {
             "DoctrineMongoODMModuleTest\\": "tests/"
         }
     }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -2,7 +2,6 @@
 chdir(dirname(__DIR__));
 
 $loader = require_once('vendor/autoload.php');
-$loader->add('DoctrineMongoODMModuleTest', __DIR__);
 
 $config = include(__DIR__ . '/test.application.config.php');
 


### PR DESCRIPTION
This PR updates the composer requirement for DoctrineModule and Doctrine ODM to the stable versions and removes the `minimum-stability: dev` directive. Furthermore, phpunit is now installed using composer to make testing easier.