### PR TITLE
Remove support for old PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": "~5.5 || ~7.0",
         "doctrine/doctrine-module": "~1.0",
         "doctrine/mongodb-odm": "~1.0",
         "zendframework/zend-mvc": "2.*",


### PR DESCRIPTION
This PR drops support for PHP 5.4, which is no longer supported. The version constraint in composer.json is also updated to allow PHP 7. While ODM does not officially support PHP 7 (due to lack of support of the legacy MongoDB driver it relies on), this allows people to use polyfills for `ext-mongo` and continue using ODM.