### PR TITLE
Removed boolean constraint from proxy and hydrator generation

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,7 @@
 <?php
+use Doctrine\Common\Proxy\AbstractProxyFactory;
+use Doctrine\ODM\MongoDB\Configuration;
+
 return array(
     'doctrine' => array(
 
@@ -20,11 +23,11 @@ return array(
 
                 'driver'             => 'odm_default',
 
-                'generate_proxies'   => true,
+                'generate_proxies'   => AbstractProxyFactory::AUTOGENERATE_ALWAYS,
                 'proxy_dir'          => 'data/DoctrineMongoODMModule/Proxy',
                 'proxy_namespace'    => 'DoctrineMongoODMModule\Proxy',
 
-                'generate_hydrators' => true,
+                'generate_hydrators' => Configuration::AUTOGENERATE_ALWAYS,
                 'hydrator_dir'       => 'data/DoctrineMongoODMModule/Hydrator',
                 'hydrator_namespace' => 'DoctrineMongoODMModule\Hydrator',
 
@@ -34,7 +37,7 @@ return array(
 
                 // custom types
                 'types'              => array()
-                
+
                 //'classMetadataFactoryName' => 'ClassName'
             )
         ),
@@ -73,7 +76,7 @@ return array(
             ),
         ),
     ),
-    
+
     'hydrators' => array(
         'factories' => array(
             'DoctrineModule\Stdlib\Hydrator\DoctrineObject' => 'DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory'

--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -156,12 +156,12 @@ class Configuration extends AbstractOptions
 
     /**
      *
-     * @param boolean $generateProxies
+     * @param boolean|int $generateProxies
      * @return \DoctrineMongoODMModule\Options\Configuration
      */
     public function setGenerateProxies($generateProxies)
     {
-        $this->generateProxies = (boolean) $generateProxies;
+        $this->generateProxies = $generateProxies;
         return $this;
     }
 
@@ -241,12 +241,12 @@ class Configuration extends AbstractOptions
 
     /**
      *
-     * @param boolean $generateHydrators
+     * @param boolean|int $generateHydrators
      * @return \DoctrineMongoODMModule\Options\Configuration
      */
     public function setGenerateHydrators($generateHydrators)
     {
-        $this->generateHydrators = (boolean) $generateHydrators;
+        $this->generateHydrators = $generateHydrators;
         return $this;
     }
 
@@ -352,7 +352,7 @@ class Configuration extends AbstractOptions
     {
         return $this->logger;
     }
-    
+
     /**
      * @return string
      */


### PR DESCRIPTION
Proxies and hydrators can have one of many implementation strategies as defined in `Doctrine\ODM\MongoDB\Configuration` and `Doctrine\Common\Proxy\AbstractProxyFactory`.