### PR TITLE
Add PHP 7 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,19 @@ php:
   - 5.5
   - 5.6
 
+env:
+  - MONGO_DRIVER=mongo
+
+matrix:
+  include:
+    - php: 7.0
+      env: ADAPTER_VERSION="^1.0.0" MONGO_DRIVER=mongodb
+
 services: mongodb
 
 before_script:
-  - echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - yes '' | pecl -q install -f $MONGO_DRIVER
+  - if [ "x${ADAPTER_VERSION}" != "x" ]; then composer require "alcaeus/mongo-php-adapter=${ADAPTER_VERSION}" --ignore-platform-reqs; fi
   - composer install --prefer-source
 
 script:


### PR DESCRIPTION
While composer.json has allowed installing on PHP 7 for a while (given that the `ext-mongo` requirement is fulfilled), there were no tests for that platform. This PR adds alcaeus/mongo-php-adapter as polyfill to the PHP 7 version of the build matrix. This follows up the discussion in #156.

Note: due to a [bug with composer](https://github.com/composer/composer/issues/5030) the build step installing the polyfill is running with the `ignore-platform-reqs` flag. Once this bug is fixed the flag should be removed.