### PR TITLE
Fixed PHPUnit warnings in PHP >= 5.6

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,21 +1,21 @@
 <?php
-return array(
-    'doctrine' => array(
+return [
+    'doctrine' => [
 
-        'connection' => array(
-            'odm_default' => array(
+        'connection' => [
+            'odm_default' => [
                 'server'           => 'localhost',
                 'port'             => '27017',
                 'connectionString' => null,
                 'user'             => null,
                 'password'         => null,
                 'dbname'           => null,
-                'options'          => array()
-            ),
-        ),
+                'options'          => []
+            ],
+        ],
 
-        'configuration' => array(
-            'odm_default' => array(
+        'configuration' => [
+            'odm_default' => [
                 'metadata_cache'     => 'array',
 
                 'driver'             => 'odm_default',
@@ -30,74 +30,74 @@ return array(
 
                 'default_db'         => null,
 
-                'filters'            => array(),  // array('filterName' => 'BSON\Filter\Class')
+                'filters'            => [],  // array('filterName' => 'BSON\Filter\Class')
 
                 // custom types
-                'types'              => array()
+                'types'              => []
                 
                 //'classMetadataFactoryName' => 'ClassName'
-            )
-        ),
+            ]
+        ],
 
-        'driver' => array(
-            'odm_default' => array(
+        'driver' => [
+            'odm_default' => [
                 'class'   => 'Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain',
-                'drivers' => array()
-            )
-        ),
+                'drivers' => []
+            ]
+        ],
 
-        'documentmanager' => array(
-            'odm_default' => array(
+        'documentmanager' => [
+            'odm_default' => [
                 'connection'    => 'odm_default',
                 'configuration' => 'odm_default',
                 'eventmanager' => 'odm_default'
-            )
-        ),
+            ]
+        ],
 
-        'eventmanager' => array(
-            'odm_default' => array(
-                'subscribers' => array()
-            )
-        ),
+        'eventmanager' => [
+            'odm_default' => [
+                'subscribers' => []
+            ]
+        ],
 
-        'mongo_logger_collector' => array(
-            'odm_default' => array(),
-        ),
+        'mongo_logger_collector' => [
+            'odm_default' => [],
+        ],
 
-        'authentication' => array(
-            'odm_default' => array(
+        'authentication' => [
+            'odm_default' => [
                 'objectManager' => 'doctrine.documentmanager.odm_default',
                 'identityClass' => 'Application\Model\User',
                 'identityProperty' => 'username',
                 'credentialProperty' => 'password'
-            ),
-        ),
-    ),
+            ],
+        ],
+    ],
     
-    'hydrators' => array(
-        'factories' => array(
+    'hydrators' => [
+        'factories' => [
             'DoctrineModule\Stdlib\Hydrator\DoctrineObject' => 'DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory'
-        )
-    ),
+        ]
+    ],
 
     // zendframework/zend-developer-tools specific settings
 
-    'view_manager' => array(
-        'template_map' => array(
+    'view_manager' => [
+        'template_map' => [
             'zend-developer-tools/toolbar/doctrine-odm' => __DIR__ . '/../view/zend-developer-tools/toolbar/doctrine-odm.phtml',
-        ),
-    ),
+        ],
+    ],
 
-    'zenddevelopertools' => array(
-        'profiler' => array(
-            'collectors' => array(
+    'zenddevelopertools' => [
+        'profiler' => [
+            'collectors' => [
                 'odm_default' => 'doctrine.mongo_logger_collector.odm_default',
-            ),
-        ),
-        'toolbar' => array(
-            'entries' => array(
+            ],
+        ],
+        'toolbar' => [
+            'entries' => [
                 'odm_default' => 'zend-developer-tools/toolbar/doctrine-odm',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/src/DoctrineMongoODMModule/Logging/DebugStack.php
+++ b/src/DoctrineMongoODMModule/Logging/DebugStack.php
@@ -27,7 +27,7 @@ namespace DoctrineMongoODMModule\Logging;
 class DebugStack implements Logger
 {
     /** @var array $queries Executed queries. */
-    public $queries = array();
+    public $queries = [];
 
     /** @var boolean $enabled If Debug Stack is enabled (log queries) or not. */
     public $enabled = true;

--- a/src/DoctrineMongoODMModule/Logging/LoggerChain.php
+++ b/src/DoctrineMongoODMModule/Logging/LoggerChain.php
@@ -26,7 +26,7 @@ namespace DoctrineMongoODMModule\Logging;
  */
 class LoggerChain implements Logger
 {
-    private $loggers = array();
+    private $loggers = [];
 
     /**
      * Adds a logger in the chain

--- a/src/DoctrineMongoODMModule/Module.php
+++ b/src/DoctrineMongoODMModule/Module.php
@@ -56,10 +56,10 @@ class Module implements
     {
         $events = $manager->getEventManager();
         // Initialize logger collector once the profiler is initialized itself
-        $events->attach('profiler_init', function(EventInterface $e) use ($manager) {
+        $events->attach('profiler_init', function (EventInterface $e) use ($manager) {
             $manager->getEvent()->getParam('ServiceManager')->get('doctrine.mongo_logger_collector.odm_default');
         });
-        $events->getSharedManager()->  attach('doctrine', 'loadCli.post', [$this, 'loadCli']);
+        $events->getSharedManager()->attach('doctrine', 'loadCli.post', [$this, 'loadCli']);
     }
 
     /**

--- a/src/DoctrineMongoODMModule/Module.php
+++ b/src/DoctrineMongoODMModule/Module.php
@@ -59,7 +59,7 @@ class Module implements
         $events->attach('profiler_init', function(EventInterface $e) use ($manager) {
             $manager->getEvent()->getParam('ServiceManager')->get('doctrine.mongo_logger_collector.odm_default');
         });
-        $events->getSharedManager()->  attach('doctrine', 'loadCli.post', array($this, 'loadCli'));
+        $events->getSharedManager()->  attach('doctrine', 'loadCli.post', [$this, 'loadCli']);
     }
 
     /**
@@ -76,7 +76,7 @@ class Module implements
      */
     public function loadCli(EventInterface $event)
     {
-        $commands = array(
+        $commands = [
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateDocumentsCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateRepositoriesCommand(),
@@ -86,7 +86,7 @@ class Module implements
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand(),
             new \Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand(),
-        );
+        ];
 
         foreach ($commands as $command) {
             $command->getDefinition()->addOption(
@@ -114,13 +114,13 @@ class Module implements
      */
     public function getAutoloaderConfig()
     {
-        return array(
-            AutoloaderFactory::STANDARD_AUTOLOADER => array(
-                StandardAutoloader::LOAD_NS => array(
+        return [
+            AutoloaderFactory::STANDARD_AUTOLOADER => [
+                StandardAutoloader::LOAD_NS => [
                     __NAMESPACE__ => __DIR__,
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     /**
@@ -136,16 +136,16 @@ class Module implements
      */
     public function getServiceConfig()
     {
-        return array(
-            'invokables' => array(
+        return [
+            'invokables' => [
                 'DoctrineMongoODMModule\Logging\DebugStack'  => 'DoctrineMongoODMModule\Logging\DebugStack',
                 'DoctrineMongoODMModule\Logging\LoggerChain' => 'DoctrineMongoODMModule\Logging\LoggerChain',
                 'DoctrineMongoODMModule\Logging\EchoLogger'  => 'DoctrineMongoODMModule\Logging\EchoLogger',
-            ),
-            'aliases' => array(
+            ],
+            'aliases' => [
                 'Doctrine\ODM\Mongo\DocumentManager' => 'doctrine.documentmanager.odm_default',
-            ),
-            'factories' => array(
+            ],
+            'factories' => [
                 'doctrine.authenticationadapter.odm_default'  => new CommonService\Authentication\AdapterFactory('odm_default'),
                 'doctrine.authenticationstorage.odm_default'  => new CommonService\Authentication\StorageFactory('odm_default'),
                 'doctrine.authenticationservice.odm_default'  => new CommonService\Authentication\AuthenticationServiceFactory('odm_default'),
@@ -155,7 +155,7 @@ class Module implements
                 'doctrine.documentmanager.odm_default' => new ODMService\DocumentManagerFactory('odm_default'),
                 'doctrine.eventmanager.odm_default'    => new CommonService\EventManagerFactory('odm_default'),
                 'doctrine.mongo_logger_collector.odm_default' => new ODMService\MongoLoggerCollectorFactory('odm_default'),
-            )
-        );
+            ]
+        ];
     }
 }

--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -100,7 +100,7 @@ class Configuration extends AbstractOptions
      *
      * @var array
      */
-    protected $filters = array();
+    protected $filters = [];
 
     /**
      *
@@ -134,7 +134,7 @@ class Configuration extends AbstractOptions
      *
      * @var array
      */
-    protected $types = array();
+    protected $types = [];
 
     /**
      *

--- a/src/DoctrineMongoODMModule/Options/Connection.php
+++ b/src/DoctrineMongoODMModule/Options/Connection.php
@@ -78,7 +78,7 @@ class Connection extends AbstractOptions
      *
      * @var array
      */
-    protected $options = array();
+    protected $options = [];
 
     /**
      *

--- a/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
@@ -33,7 +33,6 @@ use Zend\ServiceManager\ServiceLocatorInterface;
  */
 class ConfigurationFactory extends AbstractFactory
 {
-
     /**
      * @param \Zend\ServiceManager\ServiceLocatorInterface $serviceLocator
      * @return \Doctrine\ODM\MongoDB\Configuration

--- a/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
@@ -49,7 +49,7 @@ class ConfigurationFactory extends AbstractFactory
         // logger
         if ($options->getLogger()) {
             $logger = $serviceLocator->get($options->getLogger());
-            $config->setLoggerCallable(array($logger, 'log'));
+            $config->setLoggerCallable([$logger, 'log']);
         }
 
         // proxies

--- a/src/DoctrineMongoODMModule/Service/MongoLoggerCollectorFactory.php
+++ b/src/DoctrineMongoODMModule/Service/MongoLoggerCollectorFactory.php
@@ -71,9 +71,9 @@ class MongoLoggerCollectorFactory extends AbstractFactory
             $logger->addLogger($debugStackLogger);
             $callable = $configuration->getLoggerCallable();
             $logger->addLogger($callable[0]);
-            $configuration->setLoggerCallable(array($logger, 'log'));
+            $configuration->setLoggerCallable([$logger, 'log']);
         } else {
-            $configuration->setLoggerCallable(array($debugStackLogger, 'log'));
+            $configuration->setLoggerCallable([$debugStackLogger, 'log']);
         }
 
         return new MongoLoggerCollector($debugStackLogger, $options->getName());

--- a/tests/DoctrineMongoODMModuleTest/AbstractTest.php
+++ b/tests/DoctrineMongoODMModuleTest/AbstractTest.php
@@ -18,13 +18,16 @@
  */
 namespace DoctrineMongoODMModuleTest;
 
+use Doctrine\ODM\MongoDB\DocumentManager;
 use PHPUnit_Framework_TestCase;
 use Zend\Mvc\Application;
+use Zend\ServiceManager\ServiceManager;
 
 abstract class AbstractTest extends PHPUnit_Framework_TestCase
 {
-
     protected $application;
+    
+    /** @var ServiceManager */
     protected $serviceManager;
 
     protected static $applicationConfig;
@@ -40,6 +43,9 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
         self::$applicationConfig = $applicationConfig;
     }
 
+    /**
+     * @return DocumentManager
+     */
     public function getDocumentManager()
     {
         return $this->serviceManager->get('doctrine.documentmanager.odm_default');
@@ -50,7 +56,7 @@ abstract class AbstractTest extends PHPUnit_Framework_TestCase
         $connection = $this->getDocumentManager()->getConnection();
         $collections = $connection->selectDatabase('doctrineMongoODMModuleTest')->listCollections();
         foreach ($collections as $collection) {
-            $collection->remove(array(), array('w' => 1));
+            $collection->remove([], ['w' => 1]);
         }
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Assets/CustomType.php
+++ b/tests/DoctrineMongoODMModuleTest/Assets/CustomType.php
@@ -20,10 +20,6 @@ namespace DoctrineMongoODMModuleTest\Assets;
 
 use Doctrine\ODM\MongoDB\Types\IntType;
 
-/**
- * Class CustomType
- * @package DoctrineMongoODMModuleTest\Assets
- */
 class CustomType extends IntType
 {
 }

--- a/tests/DoctrineMongoODMModuleTest/Assets/ExtraAnnotation.php
+++ b/tests/DoctrineMongoODMModuleTest/Assets/ExtraAnnotation.php
@@ -21,7 +21,6 @@ namespace DoctrineMongoODMModuleTest\Assets;
 use Doctrine\Common\Annotations\Annotation;
 
 /**
- *
  * @Annotation
  * @Target({"PROPERTY"})
  */

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationAdapterFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationAdapterFactoryTest.php
@@ -24,8 +24,7 @@ class AuthenticationAdapterFactoryTest extends AbstractTest
 {
     public function testAuthenticationAdapterFactory()
     {
-
         $adapter = $this->serviceManager->get('doctrine.authenticationadapter.odm_default');
-        $this->assertInstanceOf('Zend\Authentication\Adapter\AdapterInterface', $adapter);
+        self::assertInstanceOf('Zend\Authentication\Adapter\AdapterInterface', $adapter);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationServiceFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationServiceFactoryTest.php
@@ -25,6 +25,6 @@ class AuthenticationServiceFactoryTest extends AbstractTest
     public function testAuthenticationServiceFactory()
     {
         $authenticationService = $this->serviceManager->get('doctrine.authenticationservice.odm_default');
-        $this->assertInstanceOf('Zend\Authentication\AuthenticationService', $authenticationService);
+        self::assertInstanceOf('Zend\Authentication\AuthenticationService', $authenticationService);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationStorageFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/AuthenticationStorageFactoryTest.php
@@ -25,6 +25,6 @@ class AuthenticationStorageFactoryTest extends AbstractTest
     public function testAuthenticationStorageFactory()
     {
         $storage = $this->serviceManager->get('doctrine.authenticationstorage.odm_default');
-        $this->assertInstanceOf('Zend\Authentication\Storage\StorageInterface', $storage);
+        self::assertInstanceOf('Zend\Authentication\Storage\StorageInterface', $storage);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/CliTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/CliTest.php
@@ -66,7 +66,7 @@ class CliTest extends PHPUnit_Framework_TestCase
         $this->documentManager = $serviceManager->get('doctrine.documentmanager.odm_default');
         $this->cli           = $serviceManager->get('doctrine.cli');
 
-        $this->assertSame(1, $invocations);
+        self::assertSame(1, $invocations);
     }
 
     public function testValidHelpers()
@@ -76,41 +76,41 @@ class CliTest extends PHPUnit_Framework_TestCase
         /* @var $dmHelper \Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper */
         $dmHelper = $helperSet->get('dm');
 
-        $this->assertInstanceOf('\Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper', $dmHelper);
-        $this->assertSame($this->documentManager, $dmHelper->getDocumentManager());
+        self::assertInstanceOf('\Doctrine\ODM\MongoDB\Tools\Console\Helper\DocumentManagerHelper', $dmHelper);
+        self::assertSame($this->documentManager, $dmHelper->getDocumentManager());
     }
 
     public function testValidCommands()
     {
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateDocumentsCommand',
             $this->cli->get('odm:generate:documents')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateHydratorsCommand',
             $this->cli->get('odm:generate:hydrators')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateProxiesCommand',
             $this->cli->get('odm:generate:proxies')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\GenerateRepositoriesCommand',
             $this->cli->get('odm:generate:repositories')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\QueryCommand',
             $this->cli->get('odm:query')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\CreateCommand',
             $this->cli->get('odm:schema:create')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\UpdateCommand',
             $this->cli->get('odm:schema:update')
         );
-        $this->assertInstanceOf(
+        self::assertInstanceOf(
             'Doctrine\ODM\MongoDB\Tools\Console\Command\Schema\DropCommand',
             $this->cli->get('odm:schema:drop')
         );

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationFactoryTest.php
@@ -27,14 +27,14 @@ class ConfigurationFactoryTest extends AbstractTest
     {
         $config = $this->getDocumentManager()->getConfiguration();
 
-        $this->assertSame(123, $config->getRetryConnect());
+        self::assertSame(123, $config->getRetryConnect());
     }
 
     public function testRetryQueryValueIsSetFromConfigurationOptions()
     {
         $config = $this->getDocumentManager()->getConfiguration();
 
-        $this->assertSame(456, $config->getRetryQuery());
+        self::assertSame(456, $config->getRetryQuery());
     }
 
     public function testCreation()
@@ -44,16 +44,16 @@ class ConfigurationFactoryTest extends AbstractTest
         $mappingDriver = $this->getMockForAbstractClass('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
 
         $serviceLocator = $this->getMockForAbstractClass('Zend\ServiceManager\ServiceLocatorInterface');
-        $serviceLocator->expects($this->exactly(4))->method('get')->withConsecutive(
-            array('Configuration'),
-            array('stubbed_logger'),
-            array('doctrine.cache.stubbed_metadatacache'),
-            array('doctrine.driver.stubbed_driver')
+        $serviceLocator->expects(self::exactly(4))->method('get')->withConsecutive(
+            ['Configuration'],
+            ['stubbed_logger'],
+            ['doctrine.cache.stubbed_metadatacache'],
+            ['doctrine.driver.stubbed_driver']
         )->willReturnOnConsecutiveCalls(
-            array(
-                'doctrine' => array(
-                    'configuration' => array(
-                        'odm_test' => array(
+            [
+                'doctrine' => [
+                    'configuration' => [
+                        'odm_test' => [
                             'logger'             => 'stubbed_logger',
                             'metadata_cache'     => 'stubbed_metadatacache',
                             'driver'             => 'stubbed_driver',
@@ -64,16 +64,16 @@ class ConfigurationFactoryTest extends AbstractTest
                             'hydrator_dir'       => 'data/DoctrineMongoODMModule/Hydrator',
                             'hydrator_namespace' => 'DoctrineMongoODMModule\Hydrator',
                             'default_db'         => 'default_db',
-                            'filters'            => array(),  // array('filterName' => 'BSON\Filter\Class')
+                            'filters'            => [],  // array('filterName' => 'BSON\Filter\Class')
                             // custom types
-                            'types'              => array(
+                            'types'              => [
                                 'CustomType' => 'DoctrineMongoODMModuleTest\Assets\CustomType'
-                            ),
+                            ],
                             'classMetadataFactoryName' => 'stdClass'
-                        )
-                    )
-                )
-            ),
+                        ]
+                    ]
+                ]
+            ],
             $logger,
             $metadataCache,
             $mappingDriver
@@ -82,11 +82,11 @@ class ConfigurationFactoryTest extends AbstractTest
         $factory = new ConfigurationFactory('odm_test');
         $config = $factory->createService($serviceLocator);
 
-        $this->assertInstanceOf('Doctrine\ODM\MongoDB\Configuration', $config);
-        $this->assertNotNull($config->getLoggerCallable());
-        $this->assertSame($metadataCache, $config->getMetadataCacheImpl());
-        $this->assertSame($mappingDriver, $config->getMetadataDriverImpl());
-        $this->assertInstanceOf(
+        self::assertInstanceOf('Doctrine\ODM\MongoDB\Configuration', $config);
+        self::assertNotNull($config->getLoggerCallable());
+        self::assertSame($metadataCache, $config->getMetadataCacheImpl());
+        self::assertSame($mappingDriver, $config->getMetadataDriverImpl());
+        self::assertInstanceOf(
             'DoctrineMongoODMModuleTest\Assets\CustomType',
             \Doctrine\ODM\MongoDB\Types\Type::getType('CustomType')
         );

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationTest.php
@@ -25,24 +25,24 @@ class ConfigurationTest extends PHPUnit_Framework_TestCase
 {
     public function testDefaultRetryConnectIsZero()
     {
-        $this->assertSame(0, $this->configuration->getRetryConnect());
+        self::assertSame(0, $this->configuration->getRetryConnect());
     }
 
     public function testDefaultRetryQueryIsZero()
     {
-        $this->assertSame(0, $this->configuration->getRetryQuery());
+        self::assertSame(0, $this->configuration->getRetryQuery());
     }
 
     public function testSettingRetryConnectValue()
     {
         $this->configuration->setRetryConnect(111);
-        $this->assertSame(111, $this->configuration->getRetryConnect());
+        self::assertSame(111, $this->configuration->getRetryConnect());
     }
 
     public function testSettingRetryQueryValue()
     {
         $this->configuration->setRetryQuery(222);
-        $this->assertSame(222, $this->configuration->getRetryQuery());
+        self::assertSame(222, $this->configuration->getRetryQuery());
     }
 
     public function setUp()

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ConnectionFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ConnectionFactoryTest.php
@@ -29,9 +29,9 @@ use DoctrineMongoODMModuleTest\AbstractTest;
  */
 class ConnectionFactoryTest extends AbstractTest
 {
-    private $configuration = array();
+    private $configuration = [];
 
-    private $connectionFactory = array();
+    private $connectionFactory = [];
 
     public function setup()
     {
@@ -44,67 +44,67 @@ class ConnectionFactoryTest extends AbstractTest
     public function testConnectionStringOverwritesOtherConnectionSettings()
     {
         $connectionString = 'mongodb://localhost:27017';
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'server'           => 'unreachable',
                 'port'             => '10000',
                 'connectionString' => $connectionString,
                 'user'             => 'test fails if used',
                 'password'         => 'test fails if used',
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
 
         $connection = $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($connectionString, $connection->getServer());
+        self::assertEquals($connectionString, $connection->getServer());
     }
 
     public function testConnectionStringShouldAllowMultipleHosts()
     {
         $unreachablePort  = 56000;
         $connectionString = "mongodb://localhost:$unreachablePort,localhost:27017";
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'connectionString' => $connectionString,
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
 
         $connection = $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($connectionString, $connection->getServer());
+        self::assertEquals($connectionString, $connection->getServer());
     }
 
     public function testConnectionStringShouldAllowUnixSockets()
     {
         $connectionString = 'mongodb:///tmp/mongodb-27017.sock';
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'connectionString' => $connectionString,
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
 
         $connection = $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($connectionString, $connection->getServer());
+        self::assertEquals($connectionString, $connection->getServer());
     }
 
     public function testDbNameShouldSetDefaultDB()
     {
         $dbName  = 'foo_db';
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'dbname' => $dbName,
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
@@ -113,17 +113,17 @@ class ConnectionFactoryTest extends AbstractTest
         $configuration->setDefaultDB(null);
         $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($dbName, $configuration->getDefaultDB());
+        self::assertEquals($dbName, $configuration->getDefaultDB());
     }
 
     public function testDbNameShouldNotOverrideExplicitDefaultDB()
     {
         $defaultDB  = 'foo_db';
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'dbname' => 'test fails if this is defaultDB',
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
@@ -132,18 +132,18 @@ class ConnectionFactoryTest extends AbstractTest
         $configuration->setDefaultDB($defaultDB);
         $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($defaultDB, $configuration->getDefaultDB());
+        self::assertEquals($defaultDB, $configuration->getDefaultDB());
     }
 
     public function testConnectionStringShouldSetDefaultDB()
     {
         $dbName  = 'foo_db';
         $connectionString = "mongodb://localhost:27017/$dbName";
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'connectionString' => $connectionString,
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
@@ -152,18 +152,18 @@ class ConnectionFactoryTest extends AbstractTest
         $configuration->setDefaultDB(null);
         $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($dbName, $configuration->getDefaultDB());
+        self::assertEquals($dbName, $configuration->getDefaultDB());
     }
 
     public function testConnectionStringWithOptionsShouldSetDefaultDB()
     {
         $dbName  = 'foo_db';
         $connectionString = "mongodb://localhost:27017/$dbName?bar=baz";
-        $connectionConfig = array(
-            'odm_default' => array(
+        $connectionConfig = [
+            'odm_default' => [
                 'connectionString' => $connectionString,
-            )
-        );
+            ]
+        ];
 
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('Configuration', $this->configuration);
@@ -172,6 +172,6 @@ class ConnectionFactoryTest extends AbstractTest
         $configuration->setDefaultDB(null);
         $this->connectionFactory->createService($this->serviceManager);
 
-        $this->assertEquals($dbName, $configuration->getDefaultDB());
+        self::assertEquals($dbName, $configuration->getDefaultDB());
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
@@ -18,15 +18,14 @@
  */
 namespace DoctrineMongoODMModuleTest\Doctrine;
 
-use PHPUnit_Framework_TestCase as TestCase;
 use DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory;
 use Zend\Stdlib\Hydrator\HydratorPluginManager;
 
-class DoctrineObjectHydratorFactoryTest extends TestCase
+final class DoctrineObjectHydratorFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testReturnsHydratorInstance()
     {
-        $serviceLocatorInterface = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceLocatorInterface = $this->getMockBuilder('Zend\ServiceManager\ServiceLocatorInterface')->getMock();
 
         $serviceLocatorInterface
             ->expects(self::once())
@@ -38,8 +37,8 @@ class DoctrineObjectHydratorFactoryTest extends TestCase
                      ->getMock()
             );
 
-        /** @var HydratorPluginManager $hydratorPluginManager */
-        $hydratorPluginManager = $this->getMock('Zend\Stdlib\Hydrator\HydratorPluginManager');
+        /** @var HydratorPluginManager|\PHPUnit_Framework_MockObject_MockObject $hydratorPluginManager */
+        $hydratorPluginManager = $this->getMockBuilder('Zend\Stdlib\Hydrator\HydratorPluginManager')->getMock();
 
         $hydratorPluginManager
             ->expects(self::once())

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/DoctrineObjectHydratorFactoryTest.php
@@ -29,7 +29,7 @@ class DoctrineObjectHydratorFactoryTest extends TestCase
         $serviceLocatorInterface = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
 
         $serviceLocatorInterface
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('get')
             ->with('doctrine.documentmanager.odm_default')
             ->willReturn(
@@ -42,7 +42,7 @@ class DoctrineObjectHydratorFactoryTest extends TestCase
         $hydratorPluginManager = $this->getMock('Zend\Stdlib\Hydrator\HydratorPluginManager');
 
         $hydratorPluginManager
-            ->expects($this->once())
+            ->expects(self::once())
             ->method('getServiceLocator')
             ->willReturn(
                 $serviceLocatorInterface
@@ -52,6 +52,6 @@ class DoctrineObjectHydratorFactoryTest extends TestCase
         $factory  = new DoctrineObjectHydratorFactory();
         $hydrator = $factory($hydratorPluginManager);
 
-        $this->assertInstanceOf('DoctrineModule\Stdlib\Hydrator\DoctrineObject', $hydrator);
+        self::assertInstanceOf('DoctrineModule\Stdlib\Hydrator\DoctrineObject', $hydrator);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/DocumentManagerTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/DocumentManagerTest.php
@@ -27,6 +27,6 @@ class DocumentManagerTest extends AbstractTest
     {
         $documentManager = $this->getDocumentManager();
 
-        $this->assertTrue($documentManager instanceof DocumentManager);
+        self::assertTrue($documentManager instanceof DocumentManager);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ModuleTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ModuleTest.php
@@ -32,18 +32,18 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
-        $serviceManager->expects($this->once())
+        $serviceManager->expects(self::once())
             ->method('get')
             ->with('doctrine.documentmanager.odm_default')
-            ->will($this->returnValue($documentManager));
+            ->will(self::returnValue($documentManager));
 
         $application = new Application();
-        $event = new Event('loadCli.post', $application, array('ServiceManager' => $serviceManager));
+        $event = new Event('loadCli.post', $application, ['ServiceManager' => $serviceManager]);
 
         $module = new Module();
         $module->loadCli($event);
 
-        $this->assertSame($documentManager, $application->getHelperSet()->get('documentManager')->getDocumentManager());
+        self::assertSame($documentManager, $application->getHelperSet()->get('documentManager')->getDocumentManager());
     }
 
     public function testDocumentManagerUsedCanBeSpecifiedInCommandLineArgument()
@@ -55,13 +55,13 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
-        $serviceManager->expects($this->once())
+        $serviceManager->expects(self::once())
             ->method('get')
             ->with('doctrine.documentmanager.some_other_name')
-            ->will($this->returnValue($documentManager));
+            ->will(self::returnValue($documentManager));
 
         $application = new Application();
-        $event = new Event('loadCli.post', $application, array('ServiceManager' => $serviceManager));
+        $event = new Event('loadCli.post', $application, ['ServiceManager' => $serviceManager]);
 
         $_SERVER['argv'][] = '--documentmanager=some_other_name';
 
@@ -70,6 +70,6 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $_SERVER['argv'] = $argvBackup;
 
-        $this->assertSame($documentManager, $application->getHelperSet()->get('documentManager')->getDocumentManager());
+        self::assertSame($documentManager, $application->getHelperSet()->get('documentManager')->getDocumentManager());
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ModuleTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ModuleTest.php
@@ -19,19 +19,18 @@
 namespace DoctrineMongoODMModuleTest\Doctrine;
 
 use DoctrineMongoODMModule\Module;
-use PHPUnit_Framework_TestCase;
 use Symfony\Component\Console\Application;
 use Zend\EventManager\Event;
 
-class ModuleTest extends PHPUnit_Framework_TestCase
+final class ModuleTest extends \PHPUnit_Framework_TestCase
 {
     public function testOdmDefaultIsUsedAsTheDocumentManagerIfNoneIsProvided()
     {
-        $documentManager = $this->getMockbuilder('Doctrine\ODM\MongoDB\DocumentManager')
+        $documentManager = $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceManager = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')->getMock();
         $serviceManager->expects(self::once())
             ->method('get')
             ->with('doctrine.documentmanager.odm_default')
@@ -50,11 +49,11 @@ class ModuleTest extends PHPUnit_Framework_TestCase
     {
         $argvBackup = $_SERVER['argv'];
 
-        $documentManager = $this->getMockbuilder('Doctrine\ODM\MongoDB\DocumentManager')
+        $documentManager = $this->getMockBuilder('Doctrine\ODM\MongoDB\DocumentManager')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceManager = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')->getMock();
         $serviceManager->expects(self::once())
             ->method('get')
             ->with('doctrine.documentmanager.some_other_name')

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationAdapterTest.php
@@ -43,7 +43,7 @@ class PaginationAdapterTest extends AbstractTest
         $documentManager = $this->getDocumentManager();
 
         $cursor = $documentManager->createQueryBuilder(get_class(new Simple()))->getQuery()->execute();
-        $cursor->sort(array('name' => 'asc'));
+        $cursor->sort(['name' => 'asc']);
 
         return new DoctrinePaginator($cursor);
     }
@@ -66,7 +66,7 @@ class PaginationAdapterTest extends AbstractTest
     public function testItemCount()
     {
         $paginationAdapter = $this->getPaginationAdapter();
-        $this->assertEquals($this->numberOfItems, $paginationAdapter->count());
+        self::assertEquals($this->numberOfItems, $paginationAdapter->count());
     }
 
     public function testItemCountWithEagerCursor()
@@ -75,11 +75,11 @@ class PaginationAdapterTest extends AbstractTest
 
         // Prepare an adapter with a limit already set. EagerCursors don't support $foundOnly = false
         $cursor = $documentManager->createQueryBuilder(get_class(new Simple()))->eagerCursor(true)->getQuery()->execute();
-        $cursor->sort(array('name' => 'asc'))->limit(5);
+        $cursor->sort(['name' => 'asc'])->limit(5);
 
         $paginationAdapter = new DoctrinePaginator($cursor);
 
-        $this->assertEquals($this->numberOfItems, $paginationAdapter->count());
+        self::assertEquals($this->numberOfItems, $paginationAdapter->count());
     }
 
     public function testGetItemsWithFirstFive()
@@ -87,9 +87,9 @@ class PaginationAdapterTest extends AbstractTest
         $paginationAdapter = $this->getPaginationAdapter();
         $documents = $paginationAdapter->getItems(0, 5);
 
-        $this->assertCount(5, $documents);
+        self::assertCount(5, $documents);
         for ($i = 1; $i <= 5; $i++) {
-            $this->assertEquals(sprintf('Document %02d', $i), current($documents)->getName());
+            self::assertEquals(sprintf('Document %02d', $i), current($documents)->getName());
             next($documents);
         }
     }
@@ -99,8 +99,8 @@ class PaginationAdapterTest extends AbstractTest
         $paginationAdapter = $this->getPaginationAdapter();
         $documents = $paginationAdapter->getItems($this->numberOfItems - 1, 5);
 
-        $this->assertEquals(sprintf('Document %02d', $this->numberOfItems), current($documents)->getName());
-        $this->assertCount(1, $documents);
+        self::assertEquals(sprintf('Document %02d', $this->numberOfItems), current($documents)->getName());
+        self::assertCount(1, $documents);
     }
 
     public function testGetItemsCalledTwoTimes()
@@ -110,8 +110,8 @@ class PaginationAdapterTest extends AbstractTest
         $document1 = current($paginationAdapter->getItems(0, 1));
         $document2 = current($paginationAdapter->getItems(1, 1));
 
-        $this->assertEquals('Document 01', $document1->getName());
-        $this->assertEquals('Document 02', $document2->getName());
+        self::assertEquals('Document 01', $document1->getName());
+        self::assertEquals('Document 02', $document2->getName());
     }
 
     public function testItemsAreKeyedAsSequentialIntegers()
@@ -120,7 +120,7 @@ class PaginationAdapterTest extends AbstractTest
         $items = $paginationAdapter->getItems(0, $paginationAdapter->count());
 
         for ($i = 0; $i < $paginationAdapter->count(); $i++) {
-            $this->assertArrayHasKey($i, $items);
+            self::assertArrayHasKey($i, $items);
         }
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PaginationTest.php
@@ -37,7 +37,7 @@ class PaginationTest extends AbstractTest
         $documentManager = $this->getDocumentManager();
 
         $cursor = $documentManager->createQueryBuilder(get_class(new Simple()))->getQuery()->execute();
-        $cursor->sort(array('Name', 'asc'));
+        $cursor->sort(['Name', 'asc']);
 
         return new DoctrinePaginator($cursor);
     }
@@ -67,6 +67,6 @@ class PaginationTest extends AbstractTest
         $paginator = $this->getPaginator($paginationAdapter);
         $pages = $paginator->getPages();
 
-        $this->assertEquals(10, $pages->lastItemNumber);
+        self::assertEquals(10, $pages->lastItemNumber);
     }
 }

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/PersistTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/PersistTest.php
@@ -38,6 +38,6 @@ class PersistTest extends AbstractTest
         $repository = $documentManager->getRepository(get_class($simple));
         $simple = $repository->find($id);
 
-        $this->assertEquals('lucy', $simple->getName());
+        self::assertEquals('lucy', $simple->getName());
     }
 }

--- a/tests/test.application.config.php
+++ b/tests/test.application.config.php
@@ -1,16 +1,16 @@
 <?php
 
-return array(
-    'modules' => array(
+return [
+    'modules' => [
         'DoctrineModule',
         'DoctrineMongoODMModule',
-    ),
-    'module_listener_options' => array(
-        'config_glob_paths'    => array(
+    ],
+    'module_listener_options' => [
+        'config_glob_paths'    => [
             __DIR__ . '/test.module.config.php',
-        ),
-        'module_paths' => array(
+        ],
+        'module_paths' => [
             '../vendor',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/tests/test.module.config.php
+++ b/tests/test.module.config.php
@@ -1,26 +1,26 @@
 <?php
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'odm_default' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'odm_default' => [
                 'default_db' => 'doctrineMongoODMModuleTest',
                 'retryConnect' => 123,
                 'retryQuery' => 456
-            )
-        ),
-        'driver' => array(
-            'odm_default' => array(
-                'drivers' => array(
+            ]
+        ],
+        'driver' => [
+            'odm_default' => [
+                'drivers' => [
                     'DoctrineMongoODMModuleTest\Assets\Document' => 'test'
-                )
-            ),
-            'test' => array(
+                ]
+            ],
+            'test' => [
                 'class' => 'Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver',
                 'cache' => 'array',
-                'paths' => array(
+                'paths' => [
                     __DIR__ . '/Assets/Document'
-                )
-            )
-        )
-    )
-);
+                ]
+            ]
+        ]
+    ]
+];


### PR DESCRIPTION
This builds on #164 so you might want to merge that first so the diff doesn't look so muddy. Alternatively just review [the relevant commit](https://github.com/doctrine/DoctrineMongoODMModule/commit/68a77499fd3baae560092e45a9432e0fafc94337).