### PR TITLE
Allow configuration of repository factory (as per ORM module)

### DIFF
--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -114,6 +114,12 @@ class Configuration extends AbstractOptions
     protected $classMetadataFactoryName;
 
     /**
+     *
+     * @var string
+     */
+    protected $repositoryFactory;
+
+    /**
      * Number of times to attempt to connect if an exception is encountered
      *
      * @var int
@@ -419,5 +425,21 @@ class Configuration extends AbstractOptions
     public function getTypes()
     {
         return $this->types;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRepositoryFactory() {
+        return $this->repositoryFactory;
+    }
+
+    /**
+     * @param string $repositoryFactory
+     * @return \DoctrineMongoODMModule\Options\Configuration
+     */
+    public function setRepositoryFactory($repositoryFactory) {
+        $this->repositoryFactory = (string) $repositoryFactory;
+        return $this;
     }
 }

--- a/src/DoctrineMongoODMModule/Options/Configuration.php
+++ b/src/DoctrineMongoODMModule/Options/Configuration.php
@@ -430,7 +430,8 @@ class Configuration extends AbstractOptions
     /**
      * @return string
      */
-    public function getRepositoryFactory() {
+    public function getRepositoryFactory()
+    {
         return $this->repositoryFactory;
     }
 
@@ -438,7 +439,8 @@ class Configuration extends AbstractOptions
      * @param string $repositoryFactory
      * @return \DoctrineMongoODMModule\Options\Configuration
      */
-    public function setRepositoryFactory($repositoryFactory) {
+    public function setRepositoryFactory($repositoryFactory)
+    {
         $this->repositoryFactory = (string) $repositoryFactory;
         return $this;
     }

--- a/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
@@ -86,7 +86,7 @@ class ConfigurationFactory extends AbstractFactory
         }
 
         // respositoryFactory, if set
-        if ($repositoryFactory = $options->getRepositoryFactory()){
+        if ($repositoryFactory = $options->getRepositoryFactory()) {
             $config->setRepositoryFactory($container->get($repositoryFactory));
         }
 

--- a/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConfigurationFactory.php
@@ -85,6 +85,11 @@ class ConfigurationFactory extends AbstractFactory
             $config->setClassMetadataFactoryName($factoryName);
         }
 
+        // respositoryFactory, if set
+        if ($repositoryFactory = $options->getRepositoryFactory()){
+            $config->setRepositoryFactory($container->get($repositoryFactory));
+        }
+
         // custom types
         foreach ($options->getTypes() as $name => $class) {
             if (Type::hasType($name)) {

--- a/tests/DoctrineMongoODMModuleTest/Assets/CustomRepositoryFactory.php
+++ b/tests/DoctrineMongoODMModuleTest/Assets/CustomRepositoryFactory.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+namespace DoctrineMongoODMModuleTest\Assets;
+
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
+
+/**
+ * Class CustomRepositoryFactory
+ * @package DoctrineMongoODMModuleTest\Assets
+ */
+class CustomRepositoryFactory implements RepositoryFactory
+{
+    /**
+     * Stub.
+     *
+     * @param DocumentManager $documentManager The DocumentManager instance.
+     * @param string $documentName The name of the document.
+     *
+     * @return \Doctrine\Common\Persistence\ObjectRepository
+     */
+    public function getRepository(DocumentManager $documentManager, $documentName)
+    {
+
+    }
+}

--- a/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationFactoryTest.php
+++ b/tests/DoctrineMongoODMModuleTest/Doctrine/ConfigurationFactoryTest.php
@@ -18,8 +18,10 @@
  */
 namespace DoctrineMongoODMModuleTest\Service;
 
+use Doctrine\ODM\MongoDB\Configuration;
 use DoctrineMongoODMModule\Service\ConfigurationFactory;
 use DoctrineMongoODMModuleTest\AbstractTest;
+use DoctrineMongoODMModuleTest\Assets\CustomRepositoryFactory;
 
 class ConfigurationFactoryTest extends AbstractTest
 {
@@ -42,13 +44,15 @@ class ConfigurationFactoryTest extends AbstractTest
         $logger        = $this->getMockForAbstractClass('DoctrineMongoODMModule\Logging\Logger');
         $metadataCache = $this->getMockForAbstractClass('Doctrine\Common\Cache\Cache');
         $mappingDriver = $this->getMockForAbstractClass('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver');
+        $repoFactory = new CustomRepositoryFactory();
 
         $serviceLocator = $this->getMockForAbstractClass('Zend\ServiceManager\ServiceLocatorInterface');
-        $serviceLocator->expects($this->exactly(4))->method('get')->withConsecutive(
+        $serviceLocator->expects($this->exactly(5))->method('get')->withConsecutive(
             array('Configuration'),
             array('stubbed_logger'),
             array('doctrine.cache.stubbed_metadatacache'),
-            array('doctrine.driver.stubbed_driver')
+            array('doctrine.driver.stubbed_driver'),
+            array('DoctrineMongoODMModuleTest\Assets\CustomRepositoryFactory')
         )->willReturnOnConsecutiveCalls(
             array(
                 'doctrine' => array(
@@ -69,17 +73,21 @@ class ConfigurationFactoryTest extends AbstractTest
                             'types'              => array(
                                 'CustomType' => 'DoctrineMongoODMModuleTest\Assets\CustomType'
                             ),
-                            'classMetadataFactoryName' => 'stdClass'
+                            'classMetadataFactoryName' => 'stdClass',
+                            'repositoryFactory' => 'DoctrineMongoODMModuleTest\Assets\CustomRepositoryFactory',
                         )
                     )
                 )
             ),
             $logger,
             $metadataCache,
-            $mappingDriver
+            $mappingDriver,
+            $repoFactory
         );
 
         $factory = new ConfigurationFactory('odm_test');
+
+        /** @var Configuration $config */
         $config = $factory->createService($serviceLocator);
 
         $this->assertInstanceOf('Doctrine\ODM\MongoDB\Configuration', $config);
@@ -89,6 +97,11 @@ class ConfigurationFactoryTest extends AbstractTest
         $this->assertInstanceOf(
             'DoctrineMongoODMModuleTest\Assets\CustomType',
             \Doctrine\ODM\MongoDB\Types\Type::getType('CustomType')
+        );
+
+        $this->assertInstanceOf(
+            'DoctrineMongoODMModuleTest\Assets\CustomRepositoryFactory',
+            $config->getRepositoryFactory()
         );
     }
 }


### PR DESCRIPTION
The need has arisen for me to inject a caching service into my repositories. I've found some examples for the ORM module but I noticed that the equivalent is not available for the ODM module.

http://blog.tomhanderson.com/2016/01/dependency-injection-in-doctrine.html

I checked and the RepositoryFactory was added in to ODM on 28th March 2015. It would be nice to be able to use this.

https://github.com/doctrine/mongodb-odm/pull/892
