### PR TITLE
use PHP7 compatible annotation in user guide example

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -118,7 +118,7 @@ class Message
     protected $id;
 
     /**
-     * @ODM\String
+     * @ODM\Field(type="string")
      */
     protected $text;
 


### PR DESCRIPTION
The Document in the User Guide uses the deprecated `@ODM\String` annotation