### PR TITLE
missing return type

### DIFF
--- a/src/DoctrineMongoODMModule/Logging/DebugStack.php
+++ b/src/DoctrineMongoODMModule/Logging/DebugStack.php
@@ -23,7 +23,7 @@ class DebugStack implements Logger
     /**
      * {@inheritdoc}
      */
-    public function log(array $logs)
+    public function log(array $logs):void
     {
         if (! $this->enabled) {
             return;


### PR DESCRIPTION
Declaration of DoctrineMongoODMModule\Logging\DebugStack::log(array $logs) must be compatible with DoctrineMongoODMModule\Logging\Logger::log(array $logs): void