### PR TITLE
add driverOptions configuration

### DIFF
--- a/src/DoctrineMongoODMModule/Options/Connection.php
+++ b/src/DoctrineMongoODMModule/Options/Connection.php
@@ -62,6 +62,13 @@ class Connection extends AbstractOptions
      */
     protected $options = [];
 
+    /**
+     * Driver specific connection options defined by mongodb-odm
+     *
+     * @var mixed[]
+     */
+    protected $driverOptions = [];
+
     public function getServer() : string
     {
         return $this->server;
@@ -148,6 +155,24 @@ class Connection extends AbstractOptions
     public function setOptions(array $options) : Connection
     {
         $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getDriverOptions() : array
+    {
+        return $this->driverOptions;
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function setDriverOptions(array $driverOptions) : Connection
+    {
+        $this->driverOptions = $driverOptions;
 
         return $this;
     }

--- a/src/DoctrineMongoODMModule/Service/ConnectionFactory.php
+++ b/src/DoctrineMongoODMModule/Service/ConnectionFactory.php
@@ -75,7 +75,7 @@ class ConnectionFactory extends AbstractFactory
         $eventManager = $container->get('doctrine.eventmanager.' . $this->getName());
         assert($eventManager instanceof EventManager);
 
-        return new Connection($connectionString, $options->getOptions(), $configuration, $eventManager);
+        return new Connection($connectionString, $options->getOptions(), $configuration, $eventManager,$options->getDriverOptions());
     }
 
     /**


### PR DESCRIPTION
This updates allows driver options to be sent to the Connection object.
This is is required for recent Mongo versions so that SSL config can be passed to the driver.
The functionality is supported in doctrine/mongodb-odm 1.3