### PR TITLE
Dropped PHP 7.2, added PHP 8.0

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
     with:
-      php-version: '7.4'
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,13 +16,12 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
         dependencies:
           - "highest"
         include:
-          - php-version: "7.2"
+          - php-version: "7.3"
             dependencies: "lowest"
 
     services:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
+          - "8.0"
         dependencies:
           - "highest"
         include:
@@ -51,9 +52,17 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        if: "! startsWith(matrix.php-version, '8')"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist --no-suggest"
+          composer-options: "--prefer-dist"
+
+      - name: "Install dependencies with Composer (--ignore-platform-req=php)"
+        uses: "ramsey/composer-install@v1"
+        if: "startsWith(matrix.php-version, '8')"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--prefer-dist --ignore-platform-req=php"
 
       - name: "Configure test application"
         run: "cp ./tests/TestConfiguration.php ./config/application.config.php"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.3.0"
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/composer.json
+++ b/composer.json
@@ -52,27 +52,36 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "ext-mongodb": "*",
-        "doctrine/doctrine-module": "^4.0",
-        "doctrine/mongodb-odm": "^2.0",
-        "doctrine/persistence": "^1.3 || ^2.0",
-        "laminas/laminas-mvc": "^3.1.1",
-        "laminas/laminas-servicemanager": "^3.4",
-        "laminas/laminas-stdlib": "^3.2.1",
-        "symfony/var-dumper": "^5.1"
+        "container-interop/container-interop": "^1.2.0",
+        "doctrine/doctrine-module": "^4.2.2",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
+        "doctrine/event-manager": "^1.1.1",
+        "doctrine/mongodb-odm": "^2.2.2",
+        "doctrine/persistence": "^1.3.8 || ^2.2.3",
+        "laminas/laminas-eventmanager": "^3.4.0",
+        "laminas/laminas-modulemanager": "^2.11.0",
+        "laminas/laminas-mvc": "^3.3.0",
+        "laminas/laminas-servicemanager": "^3.7.0",
+        "laminas/laminas-stdlib": "^3.6.1",
+        "symfony/console": "^5.3.0",
+        "symfony/var-dumper": "^5.3.10"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^8.2",
-        "laminas/laminas-console": "^2.8",
-        "laminas/laminas-developer-tools": "^2.0",
-        "laminas/laminas-hydrator": "^3.1.0 || 4.2.0",
-        "laminas/laminas-i18n": "^2.10.1",
-        "laminas/laminas-log": "^2.12",
-        "laminas/laminas-modulemanager": "^2.8.4",
-        "laminas/laminas-mvc-console": "^1.2",
-        "laminas/laminas-serializer": "^2.9.1",
-        "laminas/laminas-session": "^2.9.1",
-        "laminas/laminas-view": "^2.11.4",
-        "phpunit/phpunit": "^8.5.2"
+        "doctrine/coding-standard": "^8.2.1",
+        "laminas/laminas-console": "^2.8.0",
+        "laminas/laminas-developer-tools": "^2.2.0",
+        "laminas/laminas-hydrator": "^3.2.1 || ^4.3.1",
+        "laminas/laminas-i18n": "^2.11.3",
+        "laminas/laminas-log": "^2.13.1",
+        "laminas/laminas-mvc-console": "^1.3.0",
+        "laminas/laminas-serializer": "^2.11.0",
+        "laminas/laminas-session": "^2.12.0",
+        "laminas/laminas-view": "^2.14.1",
+        "phpunit/phpunit": "^8.5.21"
+    },
+    "suggest": {
+        "laminas/laminas-form": "if you want to use form elements backed by Doctrine",
+        "laminas/laminas-developer-tools": "laminas-developer-tools if you want to profile operations executed by the ODM during development"
     },
     "autoload": {
         "psr-4": {
@@ -92,9 +101,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover=coverage.xml",
-        "install-dev": "composer install",
-        "update-dev": "composer update"
+        "test-coverage": "phpunit --colors=always --coverage-clover=coverage.xml"
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "ext-mongodb": "*",
         "doctrine/doctrine-module": "^4.0",
         "doctrine/mongodb-odm": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "ext-mongodb": "*",
         "doctrine/doctrine-module": "^4.0",
         "doctrine/mongodb-odm": "^2.0",
@@ -92,7 +92,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover=clover.xml",
+        "test-coverage": "phpunit --colors=always --coverage-clover=coverage.xml",
         "install-dev": "composer install",
         "update-dev": "composer update"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       args:
-        - PHP_VERSION=${PHP_VERSION:-7.2}
+        - PHP_VERSION=${PHP_VERSION:-7.3}
         - XDEBUG=${XDEBUG:-0}
     volumes:
       - ./:/docker

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,8 +9,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.2) -->
-    <config name="php_version" value="70200"/>
+    <!-- set minimal required PHP version (7.3) -->
+    <config name="php_version" value="70300"/>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine"/>

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -6,7 +6,7 @@ namespace DoctrineMongoODMModule\Service;
 
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Doctrine\ODM\MongoDB\DocumentManager;
-use Psr\Container\ContainerInterface;
+use Interop\Container\ContainerInterface;
 
 use function assert;
 

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -7,13 +7,20 @@ namespace DoctrineMongoODMModule\Service;
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function assert;
 
-class DoctrineObjectHydratorFactory
+class DoctrineObjectHydratorFactory implements FactoryInterface
 {
-    public function __invoke(ContainerInterface $container): DoctrineObject
-    {
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName = null,
+        ?array $options = null
+    ): DoctrineObject {
         $documentManager = $container->get('doctrine.documentmanager.odm_default');
         assert($documentManager instanceof DocumentManager);
 


### PR DESCRIPTION
PHP 7.2 is dropped because it is not support by our upstream dependencies anymore. For instance, many laminas componets have already dropped PHP 7.2 a while ago and recently we also dropped PHP 7.2 in DoctrineModule.