### PR TITLE
Update PhpUnit and coding standards, add deprecations for old factory methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
         "laminas/laminas-serializer": "^2.11.0",
         "laminas/laminas-session": "^2.12.0",
         "laminas/laminas-view": "^2.14.1",
-        "phpunit/phpunit": "^8.5.21"
+        "phpspec/prophecy-phpunit": "^2.0.1",
+        "phpunit/phpunit": "^9.5.10"
     },
     "suggest": {
         "laminas/laminas-form": "if you want to use form elements backed by Doctrine",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "symfony/var-dumper": "^5.3.10"
     },
     "require-dev": {
-        "doctrine/coding-standard": "^8.2.1",
+        "doctrine/coding-standard": "^9.0.0",
         "laminas/laminas-console": "^2.8.0",
         "laminas/laminas-developer-tools": "^2.2.0",
         "laminas/laminas-hydrator": "^3.2.1 || ^4.3.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit
-    bootstrap="./vendor/autoload.php"
-    colors="true"
-    backupGlobals="false"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         verbose="true"
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="DoctrineMongoODMModule Test Suite">
-            <directory>./tests/</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -111,6 +111,8 @@ class ConfigurationFactory extends AbstractFactory
     }
 
     /**
+     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
+     *
      * @return mixed
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/ConnectionFactory.php
+++ b/src/Service/ConnectionFactory.php
@@ -84,6 +84,8 @@ class ConnectionFactory extends AbstractFactory
     }
 
     /**
+     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
+     *
      * @return mixed
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/DocumentManagerFactory.php
+++ b/src/Service/DocumentManagerFactory.php
@@ -32,6 +32,8 @@ class DocumentManagerFactory extends AbstractFactory
     }
 
     /**
+     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
+     *
      * @return mixed
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/MongoLoggerCollectorFactory.php
+++ b/src/Service/MongoLoggerCollectorFactory.php
@@ -48,6 +48,8 @@ class MongoLoggerCollectorFactory extends AbstractFactory
     }
 
     /**
+     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
+     *
      * @return mixed
      */
     public function createService(ServiceLocatorInterface $container)

--- a/tests/Doctrine/DoctrineObjectHydratorFactoryTest.php
+++ b/tests/Doctrine/DoctrineObjectHydratorFactoryTest.php
@@ -10,9 +10,12 @@ use DoctrineMongoODMModule\Service\DoctrineObjectHydratorFactory;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 class DoctrineObjectHydratorFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ServiceLocatorInterface|MockObject */
     protected $services;
 


### PR DESCRIPTION
This fixes #243, #244 and #245.

- Upgrades PhpUnit to 9.5 (requires phpspec/prophecy-phpunit for use of `prophesize()`)
- Upgrades doctrine/coding-standard to 9.0
- Marks old factory signatures as deprecated (as in [DoctrineModule](https://github.com/doctrine/DoctrineModule/commit/fa2799efb69d89141d9f4cf65c8a4b9b037e1bf2) and [DoctrineORMModule](https://github.com/doctrine/DoctrineORMModule/pull/687/commits/0d2efd6433d3ce320a18fbc3ffad356f81e07bce))