### PR TITLE
Drop PHP 7.3 and introduce typed properties

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,14 +16,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.3"
           - "7.4"
           - "8.0"
           - "8.1"
         dependencies:
           - "highest"
         include:
-          - php-version: "7.3"
+          - php-version: "7.4"
             dependencies: "lowest"
 
     services:

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,10 @@
         "sort-packages": true,
         "platform": {
             "ext-mongodb": "1.8.0"
+        },
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         }
     },
     "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-mongodb": "*",
         "container-interop/container-interop": "^1.2.0",
         "doctrine/doctrine-module": "^4.2.2",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile
       args:
-        - PHP_VERSION=${PHP_VERSION:-7.3}
+        - PHP_VERSION=${PHP_VERSION:-7.4}
         - XDEBUG=${XDEBUG:-0}
     volumes:
       - ./:/docker

--- a/docs/en/development.rst
+++ b/docs/en/development.rst
@@ -19,7 +19,7 @@ To change docker to a different php version
 
 .. code:: bash
 
-   docker-compose build --build-arg PHP_VERSION=7.3
+   docker-compose build --build-arg PHP_VERSION=7.4
 
 then run the unit tests as
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,8 +9,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.3) -->
-    <config name="php_version" value="70300"/>
+    <!-- set minimal required PHP version (7.4) -->
+    <config name="php_version" value="70400"/>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine"/>

--- a/src/Collector/MongoLoggerCollector.php
+++ b/src/Collector/MongoLoggerCollector.php
@@ -24,11 +24,9 @@ class MongoLoggerCollector implements CollectorInterface, AutoHideInterface
      */
     public const PRIORITY = 10;
 
-    /** @var DebugStack */
-    protected $mongoLogger;
+    protected DebugStack $mongoLogger;
 
-    /** @var string */
-    protected $name;
+    protected string $name;
 
     public function __construct(DebugStack $mongoLogger, string $name)
     {

--- a/src/Logging/DebugStack.php
+++ b/src/Logging/DebugStack.php
@@ -20,10 +20,10 @@ use function MongoDB\Driver\Monitoring\removeSubscriber;
 class DebugStack implements CommandLoggerInterface
 {
     /** @var mixed[] $queries Executed queries. */
-    public $queries = [];
+    public array $queries = [];
 
     /** @var bool $enabled If Debug Stack is enabled (log queries) or not. */
-    public $enabled = true;
+    public bool $enabled = true;
 
     /** @var mixed $currentQuery */
     protected $currentQuery = 0;

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -19,96 +19,73 @@ class Configuration extends AbstractOptions
      * Set the cache key for the metadata cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $metadataCache = 'array';
+    protected string $metadataCache = 'array';
 
     /**
      * Automatic generation of proxies (disable for production!)
      *
-     * @var int
      * @psalm-var MongoDbConfiguration::AUTOGENERATE_*
      */
-    protected $generateProxies = MongoDbConfiguration::AUTOGENERATE_EVAL;
+    protected int $generateProxies = MongoDbConfiguration::AUTOGENERATE_EVAL;
 
     /**
      * Proxy directory.
-     *
-     * @var string
      */
-    protected $proxyDir = 'data';
+    protected string $proxyDir = 'data';
 
     /**
      * Proxy namespace.
-     *
-     * @var string
      */
-    protected $proxyNamespace = 'DoctrineMongoODMModule\Proxy';
+    protected string $proxyNamespace = 'DoctrineMongoODMModule\Proxy';
 
     /**
      * Automatic generation of hydrators (disable for production!)
      *
-     * @var int
      * @psalm-var MongoDbConfiguration::AUTOGENERATE_*
      */
-    protected $generateHydrators = MongoDbConfiguration::AUTOGENERATE_ALWAYS;
+    protected int $generateHydrators = MongoDbConfiguration::AUTOGENERATE_ALWAYS;
 
     /**
      * Hydrator directory
-     *
-     * @var string
      */
-    protected $hydratorDir = 'data';
+    protected string $hydratorDir = 'data';
 
     /**
      * Hydrator namespace
-     *
-     * @var string
      */
-    protected $hydratorNamespace = 'DoctrineMongoODMModule\Hydrator';
+    protected string $hydratorNamespace = 'DoctrineMongoODMModule\Hydrator';
 
     /**
      * Persistent collection generation strategy.
      *
-     * @var int
      * @psalm-var MongoDbConfiguration::AUTOGENERATE_*
      */
-    protected $generatePersistentCollections = MongoDbConfiguration::AUTOGENERATE_ALWAYS;
+    protected int $generatePersistentCollections = MongoDbConfiguration::AUTOGENERATE_ALWAYS;
 
     /**
      * Persistent collection directory.
-     *
-     * @var string
      */
-    protected $persistentCollectionDir = 'data';
+    protected string $persistentCollectionDir = 'data';
 
     /**
      * Persistent collection namespace.
-     *
-     * @var string
      */
-    protected $persistentCollectionNamespace = 'DoctrineMongoODMModule\PersistentCollection';
+    protected string $persistentCollectionNamespace = 'DoctrineMongoODMModule\PersistentCollection';
 
     /**
      * Persistent collection factory service name.
-     *
-     * @var string|null
      */
-    protected $persistentCollectionFactory;
+    protected ?string $persistentCollectionFactory = null;
 
     /**
      * Persistent collection generator service name.
-     *
-     * @var string
      */
-    protected $persistentCollectionGenerator;
+    protected string $persistentCollectionGenerator;
 
-    /** @var string */
-    protected $driver;
+    protected string $driver;
 
-    /** @var string|null */
-    protected $defaultDb;
+    protected ?string $defaultDb = null;
 
     /**
      * An array of filters. Array should be in the form
@@ -116,23 +93,18 @@ class Configuration extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $filters = [];
+    protected array $filters = [];
 
     /**
      * service name of the Logger
-     *
-     * @var string|null
      */
-    protected $logger;
+    protected ?string $logger = null;
 
-    /** @var string */
-    protected $classMetadataFactoryName;
+    protected string $classMetadataFactoryName;
 
-    /** @var string */
-    protected $repositoryFactory;
+    protected string $repositoryFactory;
 
-    /** @var string */
-    protected $defaultDocumentRepositoryClassName = DefaultDocumentRepository::class;
+    protected string $defaultDocumentRepositoryClassName = DefaultDocumentRepository::class;
 
     /**
      * Keys must be the name of the type identifier and value is
@@ -140,7 +112,7 @@ class Configuration extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $types = [];
+    protected array $types = [];
 
     /**
      * @return $this

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -81,9 +81,9 @@ class Configuration extends AbstractOptions
     /**
      * Persistent collection generator service name.
      */
-    protected string $persistentCollectionGenerator;
+    protected ?string $persistentCollectionGenerator = null;
 
-    protected string $driver;
+    protected ?string $driver = null;
 
     protected ?string $defaultDb = null;
 
@@ -100,9 +100,9 @@ class Configuration extends AbstractOptions
      */
     protected ?string $logger = null;
 
-    protected string $classMetadataFactoryName;
+    protected ?string $classMetadataFactoryName = null;
 
-    protected string $repositoryFactory;
+    protected ?string $repositoryFactory = null;
 
     protected string $defaultDocumentRepositoryClassName = DefaultDocumentRepository::class;
 

--- a/src/Options/Connection.php
+++ b/src/Options/Connection.php
@@ -26,22 +26,22 @@ class Connection extends AbstractOptions
     /**
      * Username if using mongo auth
      */
-    protected string $user = null;
+    protected ?string $user = null;
 
     /**
      * Password if using mongo auth
      */
-    protected string $password = null;
+    protected ?string $password = null;
 
     /**
      * If you want to connect to a specific database
      */
-    protected string $dbname = null;
+    protected ?string $dbname = null;
 
     /**
      * If you want to provide a custom connection string
      */
-    protected string $connectionString = null;
+    protected ?string $connectionString = null;
 
     /**
      * Further connection options defined by mongodb-odm
@@ -105,7 +105,7 @@ class Connection extends AbstractOptions
         return $this;
     }
 
-    public function getDbname(): string
+    public function getDbname(): ?string
     {
         return $this->dbname;
     }

--- a/src/Options/Connection.php
+++ b/src/Options/Connection.php
@@ -15,59 +15,47 @@ class Connection extends AbstractOptions
 {
     /**
      * The server with the mongo instance you want to connect to
-     *
-     * @var string
      */
-    protected $server = 'localhost';
+    protected string $server = 'localhost';
 
     /**
      * Port to connect over
-     *
-     * @var string
      */
-    protected $port = '27017';
+    protected string $port = '27017';
 
     /**
      * Username if using mongo auth
-     *
-     * @var string
      */
-    protected $user = null;
+    protected string $user = null;
 
     /**
      * Password if using mongo auth
-     *
-     * @var string
      */
-    protected $password = null;
+    protected string $password = null;
 
     /**
      * If you want to connect to a specific database
-     *
-     * @var string
      */
-    protected $dbname = null;
+    protected string $dbname = null;
 
     /**
      * If you want to provide a custom connection string
-     *
-     * @var string
      */
-    protected $connectionString = null;
+    protected string $connectionString = null;
 
     /**
      * Further connection options defined by mongodb-odm
      *
      * @var mixed[]
      */
-    protected $options = [];
+    protected array $options = [];
 
     /**
      * Driver specific connection options defined by mongodb-odm
      *
      * @var mixed[]
      */
-    protected $driverOptions = [];
+    protected array $driverOptions = [];
 
     public function getServer(): string
     {

--- a/src/Options/DocumentManager.php
+++ b/src/Options/DocumentManager.php
@@ -17,28 +17,22 @@ class DocumentManager extends AbstractOptions
      * Set the configuration key for the Configuration. Configuration key
      * is assembled as "doctrine.configuration.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $configuration = 'odm_default';
+    protected string $configuration = 'odm_default';
 
     /**
      * Set the connection key for the Connection. Connection key
      * is assembled as "doctrine.connection.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $connection = 'odm_default';
+    protected string $connection = 'odm_default';
 
     /**
      * Set the event manager key for the event manager. Key
      * is assembled as "doctrine.eventManager.{key} and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $eventManager = 'odm_default';
+    protected string $eventManager = 'odm_default';
 
     /**
      * @param mixed $configuration

--- a/src/Options/MongoLoggerCollector.php
+++ b/src/Options/MongoLoggerCollector.php
@@ -14,13 +14,13 @@ use Laminas\Stdlib\AbstractOptions;
 class MongoLoggerCollector extends AbstractOptions
 {
     /** @var string name to be assigned to the collector */
-    protected $name = 'odm_default';
+    protected string $name = 'odm_default';
 
     /** @var string|null service name of the configuration where the logger has to be put */
-    protected $configuration;
+    protected ?string $configuration = null;
 
     /** @var string|null service name of the Logger to be used */
-    protected $mongoLogger;
+    protected ?string $mongoLogger = null;
 
     public function setName(string $name): void
     {

--- a/src/Service/MongoLoggerCollectorFactory.php
+++ b/src/Service/MongoLoggerCollectorFactory.php
@@ -19,8 +19,7 @@ use function assert;
  */
 class MongoLoggerCollectorFactory extends AbstractFactory
 {
-    /** @var string */
-    protected $name;
+    protected string $name;
 
     public function __construct(string $name)
     {

--- a/src/Service/MongoLoggerCollectorFactory.php
+++ b/src/Service/MongoLoggerCollectorFactory.php
@@ -19,8 +19,6 @@ use function assert;
  */
 class MongoLoggerCollectorFactory extends AbstractFactory
 {
-    protected string $name;
-
     public function __construct(string $name)
     {
         parent::__construct($name);

--- a/tests/Doctrine/CliTest.php
+++ b/tests/Doctrine/CliTest.php
@@ -37,11 +37,9 @@ use function assert;
  */
 class CliTest extends TestCase
 {
-    /** @var Application */
-    protected $cli;
+    protected Application $cli;
 
-    /** @var DocumentManager */
-    protected $documentManager;
+    protected DocumentManager $documentManager;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/ConnectionFactoryTest.php
+++ b/tests/Doctrine/ConnectionFactoryTest.php
@@ -14,10 +14,9 @@ use DoctrineMongoODMModuleTest\AbstractTest;
 class ConnectionFactoryTest extends AbstractTest
 {
     /** @var mixed[] $configuration */
-    private $configuration;
+    private array $configuration;
 
-    /** @var ConnectionFactory $connectionFactory */
-    private $connectionFactory;
+    private ConnectionFactory $connectionFactory;
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/DocumentManagerTest.php
+++ b/tests/Doctrine/DocumentManagerTest.php
@@ -10,7 +10,7 @@ use DoctrineMongoODMModuleTest\AbstractTest;
 final class DocumentManagerTest extends AbstractTest
 {
     /** @var mixed[] $configuration */
-    private $configuration = [];
+    private array $configuration = [];
 
     protected function setUp(): void
     {

--- a/tests/Doctrine/MongoLoggerCollectorTest.php
+++ b/tests/Doctrine/MongoLoggerCollectorTest.php
@@ -10,10 +10,8 @@ use PHPUnit\Framework\TestCase;
 
 class MongoLoggerCollectorTest extends TestCase
 {
-    /** @var DebugStack */
-    private $logger;
-    /** @var MongoLoggerCollector */
-    private $collector;
+    private DebugStack $logger;
+    private MongoLoggerCollector $collector;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
This will be a BC break targeted at the upcoming 4.0.0 release.

PHP 7.3 is dropped, because the upstream libraries (DoctrineModule and doctrine-laminas-hydrator, as well as several Laminas packages) do not support PHP 7.3 anymore.