### PR TITLE
Removed signatures related to laminas-servicemanager 2.x

### DIFF
--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -8,7 +8,6 @@ use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Types\Type;
 use DoctrineMongoODMModule\Options;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function assert;
 
@@ -108,16 +107,6 @@ class ConfigurationFactory extends AbstractFactory
         }
 
         return $config;
-    }
-
-    /**
-     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
-     *
-     * @return mixed
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, Configuration::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/ConnectionFactory.php
+++ b/src/Service/ConnectionFactory.php
@@ -8,7 +8,6 @@ use Doctrine\Common\EventManager;
 use Doctrine\ODM\MongoDB\Configuration;
 use DoctrineMongoODMModule\Options;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use MongoDB\Client;
 
 use function assert;
@@ -81,16 +80,6 @@ class ConnectionFactory extends AbstractFactory
         $driverOptions['typeMap'] = ['root' => 'array', 'document' => 'array'];
 
         return new Client($connectionString, $connectionOptions->getOptions(), $driverOptions);
-    }
-
-    /**
-     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
-     *
-     * @return mixed
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, Client::class);
     }
 
     /**

--- a/src/Service/DocumentManagerFactory.php
+++ b/src/Service/DocumentManagerFactory.php
@@ -7,7 +7,6 @@ namespace DoctrineMongoODMModule\Service;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use DoctrineMongoODMModule\Options;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function assert;
 
@@ -32,16 +31,6 @@ class DocumentManagerFactory extends AbstractFactory
         $eventManager = $container->get($options->getEventManager());
 
         return DocumentManager::create($connection, $config, $eventManager);
-    }
-
-    /**
-     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
-     *
-     * @return mixed
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, DocumentManager::class);
     }
 
     /**

--- a/src/Service/MongoLoggerCollectorFactory.php
+++ b/src/Service/MongoLoggerCollectorFactory.php
@@ -8,7 +8,6 @@ use DoctrineMongoODMModule\Collector\MongoLoggerCollector;
 use DoctrineMongoODMModule\Logging\DebugStack;
 use DoctrineMongoODMModule\Options;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function assert;
 
@@ -45,16 +44,6 @@ class MongoLoggerCollectorFactory extends AbstractFactory
         }
 
         return new MongoLoggerCollector($debugStackLogger, $settings->getName());
-    }
-
-    /**
-     * @deprecated 3.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 4.0.0.
-     *
-     * @return mixed
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, MongoLoggerCollector::class);
     }
 
     public function getOptionsClass(): string

--- a/tests/Doctrine/ConfigurationFactoryTest.php
+++ b/tests/Doctrine/ConfigurationFactoryTest.php
@@ -93,7 +93,7 @@ final class ConfigurationFactoryTest extends AbstractTest
         );
 
         $factory = new ConfigurationFactory('odm_test');
-        $config  = $factory->createService($serviceLocator);
+        $config  = $factory($serviceLocator, Config::class);
 
         assert($config instanceof Config);
 

--- a/tests/Doctrine/ConnectionFactoryTest.php
+++ b/tests/Doctrine/ConnectionFactoryTest.php
@@ -7,6 +7,7 @@ namespace DoctrineMongoODMModuleTest\Doctrine;
 use Doctrine\ODM\MongoDB\Configuration;
 use DoctrineMongoODMModule\Service\ConnectionFactory;
 use DoctrineMongoODMModuleTest\AbstractTest;
+use MongoDB\Client;
 
 /**
  * @covers  \DoctrineMongoODMModule\Service\ConnectionFactory
@@ -45,7 +46,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('config', $this->configuration);
 
-        $connection = $this->connectionFactory->createService($this->serviceManager);
+        $connection = ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($connectionString, (string) $connection);
     }
@@ -61,7 +62,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('config', $this->configuration);
 
-        $connection = $this->connectionFactory->createService($this->serviceManager);
+        $connection = ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($connectionString, (string) $connection);
     }
@@ -76,7 +77,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->configuration['doctrine']['connection'] = $connectionConfig;
         $this->serviceManager->setService('config', $this->configuration);
 
-        $connection = $this->connectionFactory->createService($this->serviceManager);
+        $connection = ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($connectionString, (string) $connection);
     }
@@ -93,7 +94,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->configuration['doctrine']['configuration'] = $configurationConfig;
         $this->serviceManager->setService('config', $this->configuration);
 
-        $this->connectionFactory->createService($this->serviceManager);
+        ($this->connectionFactory)($this->serviceManager, Client::class);
         $configuration = $this->getConfiguration();
 
         $this->assertEquals($dbName, $configuration->getDefaultDB());
@@ -111,7 +112,7 @@ class ConnectionFactoryTest extends AbstractTest
 
         $configuration = $this->getConfiguration();
         $configuration->setDefaultDB($defaultDB);
-        $this->connectionFactory->createService($this->serviceManager);
+        ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($defaultDB, $configuration->getDefaultDB());
     }
@@ -130,7 +131,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->serviceManager->setService('config', $this->configuration);
 
         $configuration = $this->getConfiguration();
-        $this->connectionFactory->createService($this->serviceManager);
+        ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($dbName, $configuration->getDefaultDB());
     }
@@ -149,7 +150,7 @@ class ConnectionFactoryTest extends AbstractTest
         $this->serviceManager->setService('config', $this->configuration);
 
         $configuration = $this->getConfiguration();
-        $this->connectionFactory->createService($this->serviceManager);
+        ($this->connectionFactory)($this->serviceManager, Client::class);
 
         $this->assertEquals($dbName, $configuration->getDefaultDB());
     }

--- a/tests/Doctrine/MongoLoggerCollectorFactoryTest.php
+++ b/tests/Doctrine/MongoLoggerCollectorFactoryTest.php
@@ -21,7 +21,7 @@ class MongoLoggerCollectorFactoryTest extends AbstractTest
     {
         $factory = new MongoLoggerCollectorFactory('odm_default');
 
-        $collector = $factory->createService($this->serviceManager);
+        $collector = $factory($this->serviceManager, MongoLoggerCollector::class);
 
         $this->assertInstanceOf(MongoLoggerCollector::class, $collector);
     }


### PR DESCRIPTION
In laminas-servicemanager 2.x, the `FactoryInterface` included the following methods:
 - `public function createService(ServiceLocatorInterface $serviceLocator)`
 - `public function setCreationOptions(array $options)`

These methods are replaced by the following method in laminas-servicemanager 3.x:
 - `public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)`

Since DoctrineMongoODMModule already requires laminas-servicemanager 3.x for nearly two years, it is time to drop the obsolete functions `createService()` and `setCreationOptions()` in all factories. All factories already implement a `__invoke()` method.

This is the same as done in doctrine/DoctrineModule#763