### PR TITLE
Mark `Module`, option classes and factories as final

### DIFF
--- a/src/Module.php
+++ b/src/Module.php
@@ -25,10 +25,8 @@ use function sprintf;
 
 /**
  * Doctrine Module provider for Mongo DB ODM.
- *
- * @link    http://www.doctrine-project.org
  */
-class Module implements InitProviderInterface, ConfigProviderInterface, ServiceProviderInterface
+final class Module implements InitProviderInterface, ConfigProviderInterface, ServiceProviderInterface
 {
     public function init(ModuleManagerInterface $manager): void
     {

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -10,10 +10,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for doctrine mongo
- *
- * @link    http://www.doctrine-project.org/
  */
-class Configuration extends AbstractOptions
+final class Configuration extends AbstractOptions
 {
     /**
      * Set the cache key for the metadata cache. Cache key

--- a/src/Options/Connection.php
+++ b/src/Options/Connection.php
@@ -8,10 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Connection options for doctrine mongo
- *
- * @link    http://www.doctrine-project.org/
  */
-class Connection extends AbstractOptions
+final class Connection extends AbstractOptions
 {
     /**
      * The server with the mongo instance you want to connect to

--- a/src/Options/DocumentManager.php
+++ b/src/Options/DocumentManager.php
@@ -8,10 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Document manager options for doctrine mongo
- *
- * @link    http://www.doctrine-project.org/
  */
-class DocumentManager extends AbstractOptions
+final class DocumentManager extends AbstractOptions
 {
     /**
      * Set the configuration key for the Configuration. Configuration key

--- a/src/Options/MongoLoggerCollector.php
+++ b/src/Options/MongoLoggerCollector.php
@@ -8,10 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for a collector
- *
- * @link    http://www.doctrine-project.org/
  */
-class MongoLoggerCollector extends AbstractOptions
+final class MongoLoggerCollector extends AbstractOptions
 {
     /** @var string name to be assigned to the collector */
     protected $name = 'odm_default';

--- a/src/Service/AbstractFactory.php
+++ b/src/Service/AbstractFactory.php
@@ -11,6 +11,9 @@ use RuntimeException;
 
 use function sprintf;
 
+/**
+ * @internal
+ */
 // phpcs:disable SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming
 abstract class AbstractFactory extends DoctrineModuleAbstractFactory
 {

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -14,10 +14,8 @@ use function assert;
 
 /**
  * Factory to create MongoDB configuration object.
- *
- * @link    http://www.doctrine-project.org/
  */
-class ConfigurationFactory extends AbstractFactory
+final class ConfigurationFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/ConnectionFactory.php
+++ b/src/Service/ConnectionFactory.php
@@ -19,10 +19,8 @@ use const PHP_INT_MAX;
 
 /**
  * Factory creates a mongo connection
- *
- * @link    http://www.doctrine-project.org/
  */
-class ConnectionFactory extends AbstractFactory
+final class ConnectionFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -11,7 +11,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function assert;
 
-class DoctrineObjectHydratorFactory implements FactoryInterface
+final class DoctrineObjectHydratorFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/DocumentManagerFactory.php
+++ b/src/Service/DocumentManagerFactory.php
@@ -13,10 +13,8 @@ use function assert;
 
 /**
  * Factory creates a mongo document manager
- *
- * @link    http://www.doctrine-project.org/
  */
-class DocumentManagerFactory extends AbstractFactory
+final class DocumentManagerFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/MongoLoggerCollectorFactory.php
+++ b/src/Service/MongoLoggerCollectorFactory.php
@@ -14,10 +14,8 @@ use function assert;
 
 /**
  * Mongo Logger Configuration ServiceManager factory
- *
- * @link    http://www.doctrine-project.org/
  */
-class MongoLoggerCollectorFactory extends AbstractFactory
+final class MongoLoggerCollectorFactory extends AbstractFactory
 {
     /** @var string */
     protected $name;


### PR DESCRIPTION
The Module class as well as the option classes and all factories are no valid extension points. They are now marked as final.

This is in line with doctrine/DoctrineModule#766.