### PR TITLE
Fix compatibility issue with DoctrineModule 5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-mongodb": "*",
         "container-interop/container-interop": "^1.2.0",
-        "doctrine/doctrine-module": "^5.0.0",
+        "doctrine/doctrine-module": "^5.0.0 <5.2.0",
         "doctrine/doctrine-laminas-hydrator": "^2.2.1 || ^3.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/mongodb-odm": "^2.3.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,5 @@ services:
       - ./docker/php.ini:/usr/local/etc/php/php.ini
     depends_on:
       - mongodb
-    environment:
-        - TRAVIS
-        - TRAVIS_JOB_ID
-        - TRAVIS_BRANCH
-        - TRAVIS_PULL_REQUEST
   mongodb:
     image: mongo:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,9 @@
-ARG PHP_VERSION=7.2
+ARG PHP_VERSION=7.4
 FROM php:${PHP_VERSION}-alpine
 
 ARG XDEBUG=0
 
 COPY docker/entrypoint.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/entrypoint.sh
 
 RUN apk add --no-cache \
     autoconf \
@@ -18,13 +17,15 @@ RUN apk add --no-cache \
     libxml2-dev \
     make \
     openssl-dev
-    
-RUN docker-php-ext-configure intl
-RUN docker-php-ext-install -j$(nproc) intl
-RUN pecl install mongodb
-RUN set -o pipefail && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN if [ ${XDEBUG} == "1" ] ; then pecl install xdebug && docker-php-ext-enable xdebug ; fi
-RUN composer config --global "platform.ext-mongo" "1.6.16"
+
+RUN chmod 755 /usr/local/bin/entrypoint.sh \
+    && docker-php-ext-configure intl \
+    && docker-php-ext-install -j$(nproc) intl \
+    && pecl install mongodb \
+    && set -o pipefail \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && if [ ${XDEBUG} == "1" ] ; then pecl install xdebug && docker-php-ext-enable xdebug ; fi \
+    && composer config --global "platform.ext-mongo" "1.6.16"
 
 WORKDIR /docker
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/tests/Assets/CustomRepositoryFactory.php
+++ b/tests/Assets/CustomRepositoryFactory.php
@@ -7,6 +7,7 @@ namespace DoctrineMongoODMModuleTest\Assets;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Repository\RepositoryFactory;
 use Doctrine\Persistence\ObjectRepository;
+use stdClass;
 
 class CustomRepositoryFactory implements RepositoryFactory
 {
@@ -57,7 +58,7 @@ class CustomRepositoryFactory implements RepositoryFactory
 
             public function getClassName(): string
             {
-                return '';
+                return stdClass::class;
             }
         };
     }

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DoctrineMongoODMModuleTest;
 
+use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
+
 use function getenv;
 
 return [
@@ -20,10 +22,10 @@ return [
         ],
         'driver' => [
             'odm_default' => [
-                'drivers' => ['DoctrineMongoODMModuleTest\Assets\Document' => 'test'],
+                'drivers' => ['DoctrineMongoODMModuleTest\Assets\Document' => 'test_assets'],
             ],
-            'test' => [
-                'class' => 'Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver',
+            'test_assets' => [
+                'class' => AnnotationDriver::class,
                 'cache' => 'array',
                 'paths' => [__DIR__ . '/Assets/Document'],
             ],


### PR DESCRIPTION
Since DoctrineMongoODMModule 4.0.x is officially not maintained anymore, I am releasing a fix to mark this module as incompatible to DoctrineModule >= 5.2.0. 

For the 4.1.x series I am hoping to get this running again with a new release of DoctrineModule.