### PR TITLE
Update DoctrineModule to 5.2.1 to fix #261 when using persistence v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Doctrine MongoDB ODM Module for Laminas
 
-[![Build Status](https://github.com/doctrine/DoctrineMongoODMModule/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/DoctrineMongoODMModule/actions/workflows/continuous-integration.yml?query=branch%3A3.1.x)
-[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineMongoODMModule/branch/3.0.x/graphs/badge.svg)](https://codecov.io/gh/doctrine/DoctrineMongoODMModule/branch/3.1.x)
+[![Build Status](https://github.com/doctrine/DoctrineMongoODMModule/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/DoctrineMongoODMModule/actions/workflows/continuous-integration.yml?query=branch%3A4.1.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineMongoODMModule/branch/4.1.x/graphs/badge.svg)](https://codecov.io/gh/doctrine/DoctrineMongoODMModule/branch/4.1.x)
 [![Latest Stable Version](https://poser.pugx.org/doctrine/doctrine-mongo-odm-module/v/stable.png)](https://packagist.org/packages/doctrine/doctrine-mongo-odm-module) 
 [![Total Downloads](https://poser.pugx.org/doctrine/doctrine-mongo-odm-module/downloads.png)](https://packagist.org/packages/doctrine/doctrine-mongo-odm-module)
 

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-mongodb": "*",
         "container-interop/container-interop": "^1.2.0",
-        "doctrine/doctrine-module": "^5.1.0 <5.2.0",
+        "doctrine/doctrine-module": "^5.2.1",
         "doctrine/doctrine-laminas-hydrator": "^3.0.1",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/mongodb-odm": "^2.3.2",


### PR DESCRIPTION
The upstream fix in DoctrineModule 5.2.1, see doctrine/DoctrineModule#788, should solve the issue of #261. In DoctrineModule 5.2.0 the instantiation of the MongoDB ODM annotation driver was handled incorrectly, an issue, which occurred with the release of persistence 3.0, where the annotation drivers of ODM and ORM do not share a common parent class anymore.