### PR TITLE
Avoid using deprecated methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     "require": {
         "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-mongodb": "*",
+        "doctrine/cache": "^1.11 || ^2.0",
         "doctrine/doctrine-laminas-hydrator": "^3.3.0",
         "doctrine/doctrine-module": "^6.0.4",
         "doctrine/event-manager": "^1.2.0 || ^2.0.0",

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -12,6 +12,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for doctrine mongo
+ *
+ * @extends AbstractOptions<int|string|array<string, string>|null>
  */
 final class Configuration extends AbstractOptions
 {

--- a/src/Options/Connection.php
+++ b/src/Options/Connection.php
@@ -8,6 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Connection options for doctrine mongo
+ *
+ * @extends AbstractOptions<int|string|array|null>
  */
 final class Connection extends AbstractOptions
 {

--- a/src/Options/DocumentManager.php
+++ b/src/Options/DocumentManager.php
@@ -8,6 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Document manager options for doctrine mongo
+ *
+ * @extends AbstractOptions<string>
  */
 final class DocumentManager extends AbstractOptions
 {

--- a/src/Options/MongoLoggerCollector.php
+++ b/src/Options/MongoLoggerCollector.php
@@ -8,6 +8,8 @@ use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for a collector
+ *
+ * @extends AbstractOptions<string>
  */
 final class MongoLoggerCollector extends AbstractOptions
 {

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineMongoODMModule\Service;
 
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\ODM\MongoDB\Configuration;
 use Doctrine\ODM\MongoDB\Types\Type;
 use DoctrineMongoODMModule\Options;
@@ -68,7 +69,8 @@ final class ConfigurationFactory extends AbstractFactory
         }
 
         // caching
-        $config->setMetadataCacheImpl($container->get($configurationOptions->getMetadataCache()));
+        $cache = $container->get($configurationOptions->getMetadataCache());
+        $config->setMetadataCache(CacheAdapter::wrap($cache));
 
         // Register filters
         foreach ($configurationOptions->getFilters() as $alias => $class) {

--- a/tests/Doctrine/ConfigurationFactoryTest.php
+++ b/tests/Doctrine/ConfigurationFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineMongoODMModuleTest\Doctrine;
 
 use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\ODM\MongoDB\APM\CommandLoggerInterface;
 use Doctrine\ODM\MongoDB\Configuration as Config;
 use Doctrine\ODM\MongoDB\PersistentCollection\PersistentCollectionFactory;
@@ -99,7 +100,7 @@ final class ConfigurationFactoryTest extends AbstractTest
 
         $this->assertInstanceOf(Config::class, $config);
 
-        $this->assertSame($metadataCache, $config->getMetadataCacheImpl());
+        $this->assertEquals(CacheAdapter::wrap($metadataCache), $config->getMetadataCache());
         $this->assertSame($mappingDriver, $config->getMetadataDriverImpl());
 
         $this->assertSame(Config::AUTOGENERATE_EVAL, $config->getAutoGenerateProxyClasses());


### PR DESCRIPTION
MongoDB ODM 2.2 deprecated `Doctrine\ODM\MongoDB\Configuration::getMetadataCacheImpl()` and `Doctrine\ODM\MongoDB\Configuration::setMetadataCacheImpl()` in favor of `Configuration::getMetadataCache` and `Configuration::setMetadataCache()`, respectively, which use a PSR-6 compliant cache instead of doctrine/cache.

I refrained from allowing to pass a PSR-6 `CacheItemPoolInterface` directly for now, because it's currently unlikely that a cache pulled from `doctrine.cache.[name]` service key will return a PSR-6 cache. Such a change would probably also require changes in doctrine-module and doctrine-orm-module.
But if you want me to implement that forward compatibility layer right away it's also ok for me.

fixes #279 