### PR TITLE
Updated doctrine/doctrine-module to ^6.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,22 +47,22 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-mongodb": "*",
-        "doctrine/cache": "^1.11 || ^2.0",
+        "doctrine/cache": "^2.0.0",
         "doctrine/doctrine-laminas-hydrator": "^3.3.0",
-        "doctrine/doctrine-module": "^6.1.0",
-        "doctrine/event-manager": "^1.2.0 || ^2.0.0",
+        "doctrine/doctrine-module": "^6.2.0",
+        "doctrine/event-manager": "^2.0.0",
         "doctrine/mongodb-odm": "^2.5.2",
         "laminas/laminas-eventmanager": "^3.10.0",
         "laminas/laminas-modulemanager": "^2.14.0",
         "laminas/laminas-mvc": "^3.6.1",
         "laminas/laminas-servicemanager": "^3.19.0",
         "laminas/laminas-stdlib": "^3.16.1",
-        "symfony/console": "^5.4.26 || ^6.3.2",
-        "symfony/var-dumper": "^5.4.26 || ^6.3.2"
+        "symfony/console": "^6.3.2 || ^7.0.0",
+        "symfony/var-dumper": "^6.3.2 || ^7.0.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^12.0.0",
-        "doctrine/persistence": "^2.5.7 || ^3.4.0",
+        "doctrine/persistence": "^3.4.0",
         "jangregor/phpstan-prophecy": "^2.0.0",
         "laminas/laminas-developer-tools": "^2.9.0",
         "laminas/laminas-hydrator": "^4.16.0",


### PR DESCRIPTION
This PR upgrades `doctrine/doctrine-module` from 6.1.x to 6.2.x. This update brings a couple of changes, see the release notes of DoctrineModule 6.2.0:

> ### [Release Notes for 6.2.0](https://github.com/doctrine/DoctrineModule/releases/tag/6.2.0)
> 
> Feature release (minor)
> 
> ### Changed
> 
> - doctrine/annotations ^2 is now required (1.x is not supported anymore)
> - doctrine/cache ^2 is now required (1.x is not supported anymore) - **Note:** This change implies that laminas-cache is now used for caching, as doctrine/cache v2 does not contain implementations anymore. Using laminas-cache, however, is the default config since the 6.0.0 release. If you are using other adapters than `array` and `filesystem`, you might need to require additional laminas packages!
> - doctrine/collections ^2 is now required (1.x is not supported anymore)
> - doctrine/event-manager ^2 is now required (1.x is not supported anymore)
> - doctrine/persistence ^3 is now required (2.x is not supported anymore)
> - symfony/console ^7 is now alled besides 6.x (5.x is not supported anymore)
> 
> ### Dropped
> 
> - Support for PHP 8.0 has been dropped